### PR TITLE
Implement Milestone 3: Apache Parser

### DIFF
--- a/cmd/blazectl/cmd/parse.go
+++ b/cmd/blazectl/cmd/parse.go
@@ -119,8 +119,10 @@ func getParser(logType string) (parser.Parser, bool) {
 		return parser.NewNginxAccessParser(nil), true
 	case "nginx-error":
 		return parser.NewNginxErrorParser(nil), true
-	case "apache":
-		return nil, false // Will be implemented in Milestone 3
+	case "apache", "apache-access":
+		return parser.NewApacheAccessParser(nil), true
+	case "apache-error":
+		return parser.NewApacheErrorParser(nil), true
 	case "magento":
 		return nil, false // Will be implemented in Milestone 4
 	case "prestashop":

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/good-yellow-bee/blazelog
 
-go 1.25.5
+go 1.24.7
 
 require github.com/spf13/cobra v1.10.2
 

--- a/internal/parser/apache_access.go
+++ b/internal/parser/apache_access.go
@@ -1,0 +1,189 @@
+// Package parser provides log parsing functionality for various log formats.
+package parser
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+// ApacheAccessParser parses Apache access logs.
+// Supports both combined and common log formats.
+type ApacheAccessParser struct {
+	*BaseParser
+	combinedRegex *regexp.Regexp
+	commonRegex   *regexp.Regexp
+}
+
+// Apache access log timestamp format (same as Nginx)
+const apacheAccessTimeFormat = "02/Jan/2006:15:04:05 -0700"
+
+// NewApacheAccessParser creates a new Apache access log parser.
+func NewApacheAccessParser(opts *ParserOptions) *ApacheAccessParser {
+	return &ApacheAccessParser{
+		BaseParser: NewBaseParser(opts),
+		// Combined format: %h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i"
+		// Example: 127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/" "Mozilla/5.0"
+		combinedRegex: regexp.MustCompile(`^(\S+) (\S+) (\S+) \[([^\]]+)\] "(\S+) (\S+) (\S+)" (\d+) (\d+|-) "([^"]*)" "([^"]*)"$`),
+		// Common format: %h %l %u %t "%r" %>s %b
+		// Example: 127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326
+		commonRegex: regexp.MustCompile(`^(\S+) (\S+) (\S+) \[([^\]]+)\] "(\S+) (\S+) (\S+)" (\d+) (\d+|-)$`),
+	}
+}
+
+// Parse parses a single Apache access log line.
+func (p *ApacheAccessParser) Parse(line string) (*models.LogEntry, error) {
+	return p.ParseWithContext(context.Background(), line)
+}
+
+// ParseWithContext parses a single Apache access log line with context support.
+func (p *ApacheAccessParser) ParseWithContext(ctx context.Context, line string) (*models.LogEntry, error) {
+	if line == "" {
+		return nil, ErrEmptyLine
+	}
+
+	entry := models.NewLogEntry()
+	entry.Type = models.LogTypeApache
+
+	// Try combined format first (most common in production)
+	if matches := p.combinedRegex.FindStringSubmatch(line); matches != nil {
+		return p.parseCombined(entry, line, matches)
+	}
+
+	// Try common format
+	if matches := p.commonRegex.FindStringSubmatch(line); matches != nil {
+		return p.parseCommon(entry, line, matches)
+	}
+
+	return nil, ErrInvalidFormat
+}
+
+// parseCombined parses the combined log format.
+func (p *ApacheAccessParser) parseCombined(entry *models.LogEntry, line string, matches []string) (*models.LogEntry, error) {
+	// Parse common fields first (indices 1-9)
+	if err := p.parseCommonFields(entry, matches[1:10]); err != nil {
+		return nil, err
+	}
+
+	// Additional fields from combined format
+	referer := matches[10]
+	if referer != "-" && referer != "" {
+		entry.SetField("http_referer", referer)
+	}
+
+	userAgent := matches[11]
+	if userAgent != "-" && userAgent != "" {
+		entry.SetField("http_user_agent", userAgent)
+	}
+
+	// Build message
+	entry.Message = buildApacheAccessMessage(entry)
+
+	p.ApplyOptions(entry, line)
+	return entry, nil
+}
+
+// parseCommon parses the common log format.
+func (p *ApacheAccessParser) parseCommon(entry *models.LogEntry, line string, matches []string) (*models.LogEntry, error) {
+	if err := p.parseCommonFields(entry, matches[1:10]); err != nil {
+		return nil, err
+	}
+
+	// Build message
+	entry.Message = buildApacheAccessMessage(entry)
+
+	p.ApplyOptions(entry, line)
+	return entry, nil
+}
+
+// parseCommonFields parses fields common to both formats.
+// Fields: remote_host, ident, remote_user, time_local, method, request_uri, protocol, status, bytes_sent
+func (p *ApacheAccessParser) parseCommonFields(entry *models.LogEntry, fields []string) error {
+	// Remote host (IP address)
+	entry.SetField("remote_host", fields[0])
+
+	// Ident (usually "-")
+	ident := fields[1]
+	if ident != "-" {
+		entry.SetField("ident", ident)
+	}
+
+	// Remote user (may be "-")
+	remoteUser := fields[2]
+	if remoteUser != "-" {
+		entry.SetField("remote_user", remoteUser)
+	}
+
+	// Timestamp
+	timestamp, err := time.Parse(apacheAccessTimeFormat, fields[3])
+	if err != nil {
+		return ErrInvalidFormat
+	}
+	entry.Timestamp = timestamp
+
+	// Request parts
+	entry.SetField("method", fields[4])
+	entry.SetField("request_uri", fields[5])
+	entry.SetField("protocol", fields[6])
+
+	// Status code
+	status, err := strconv.Atoi(fields[7])
+	if err != nil {
+		return ErrInvalidFormat
+	}
+	entry.SetField("status", status)
+
+	// Set log level based on status code
+	entry.Level = apacheStatusToLevel(status)
+
+	// Bytes sent (may be "-" for no content)
+	bytesSent := fields[8]
+	if bytesSent != "-" {
+		bytes, err := strconv.Atoi(bytesSent)
+		if err == nil {
+			entry.SetField("bytes_sent", bytes)
+		}
+	} else {
+		entry.SetField("bytes_sent", 0)
+	}
+
+	return nil
+}
+
+// apacheStatusToLevel converts HTTP status code to log level.
+func apacheStatusToLevel(status int) models.LogLevel {
+	switch {
+	case status >= 500:
+		return models.LevelError
+	case status >= 400:
+		return models.LevelWarning
+	default:
+		return models.LevelInfo
+	}
+}
+
+// buildApacheAccessMessage builds a human-readable message from access log fields.
+func buildApacheAccessMessage(entry *models.LogEntry) string {
+	method := entry.GetFieldString("method")
+	uri := entry.GetFieldString("request_uri")
+	status := entry.GetFieldInt("status")
+	return method + " " + uri + " " + strconv.Itoa(status)
+}
+
+// Name returns the parser name.
+func (p *ApacheAccessParser) Name() string {
+	return "apache-access"
+}
+
+// Type returns the log type this parser handles.
+func (p *ApacheAccessParser) Type() models.LogType {
+	return models.LogTypeApache
+}
+
+// CanParse returns true if the line looks like an Apache access log.
+func (p *ApacheAccessParser) CanParse(line string) bool {
+	return p.combinedRegex.MatchString(line) || p.commonRegex.MatchString(line)
+}

--- a/internal/parser/apache_error.go
+++ b/internal/parser/apache_error.go
@@ -1,0 +1,231 @@
+// Package parser provides log parsing functionality for various log formats.
+package parser
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+// ApacheErrorParser parses Apache error logs.
+// Supports Apache 2.4+ format and Apache 2.2 format.
+type ApacheErrorParser struct {
+	*BaseParser
+	// Apache 2.4+ format: [timestamp] [module:level] [pid pid:tid tid] [client ip:port] message
+	regex24     *regexp.Regexp
+	// Apache 2.2 format: [timestamp] [level] [client ip] message
+	regex22     *regexp.Regexp
+	// Simplified 2.2 format without client: [timestamp] [level] message
+	regex22NoClient *regexp.Regexp
+}
+
+// Apache 2.4+ error log timestamp format: Sat Oct 10 14:32:52.123456 2020
+const apache24ErrorTimeFormat = "Mon Jan 02 15:04:05.000000 2006"
+
+// Apache 2.2 error log timestamp format: Sat Oct 10 14:32:52 2020
+const apache22ErrorTimeFormat = "Mon Jan 02 15:04:05 2006"
+
+// NewApacheErrorParser creates a new Apache error log parser.
+func NewApacheErrorParser(opts *ParserOptions) *ApacheErrorParser {
+	return &ApacheErrorParser{
+		BaseParser: NewBaseParser(opts),
+		// Apache 2.4+ format with full details
+		// Example: [Sat Oct 10 14:32:52.123456 2020] [core:error] [pid 12345:tid 123456789] [client 192.168.1.1:56789] AH00124: Request exceeded the limit
+		regex24: regexp.MustCompile(`^\[([^\]]+)\] \[([^:\]]+):([^\]]+)\] \[pid (\d+):tid (\d+)\](?: \[client ([^\]]+)\])? (.+)$`),
+		// Apache 2.2 format with client
+		// Example: [Sat Oct 10 14:32:52 2020] [error] [client 192.168.1.1] File does not exist: /var/www/html/missing.html
+		regex22: regexp.MustCompile(`^\[([^\]]+)\] \[(\w+)\] \[client ([^\]]+)\] (.+)$`),
+		// Apache 2.2 format without client
+		// Example: [Sat Oct 10 14:32:52 2020] [notice] Apache/2.2.22 configured
+		regex22NoClient: regexp.MustCompile(`^\[([^\]]+)\] \[(\w+)\] (.+)$`),
+	}
+}
+
+// Parse parses a single Apache error log line.
+func (p *ApacheErrorParser) Parse(line string) (*models.LogEntry, error) {
+	return p.ParseWithContext(context.Background(), line)
+}
+
+// ParseWithContext parses a single Apache error log line with context support.
+func (p *ApacheErrorParser) ParseWithContext(ctx context.Context, line string) (*models.LogEntry, error) {
+	if line == "" {
+		return nil, ErrEmptyLine
+	}
+
+	entry := models.NewLogEntry()
+	entry.Type = models.LogTypeApache
+
+	// Try Apache 2.4+ format first (most common)
+	if matches := p.regex24.FindStringSubmatch(line); matches != nil {
+		return p.parseApache24(entry, line, matches)
+	}
+
+	// Try Apache 2.2 format with client
+	if matches := p.regex22.FindStringSubmatch(line); matches != nil {
+		return p.parseApache22WithClient(entry, line, matches)
+	}
+
+	// Try Apache 2.2 format without client
+	if matches := p.regex22NoClient.FindStringSubmatch(line); matches != nil {
+		return p.parseApache22NoClient(entry, line, matches)
+	}
+
+	return nil, ErrInvalidFormat
+}
+
+// parseApache24 parses Apache 2.4+ error log format.
+func (p *ApacheErrorParser) parseApache24(entry *models.LogEntry, line string, matches []string) (*models.LogEntry, error) {
+	// Parse timestamp
+	timestamp, err := parseApacheErrorTimestamp(matches[1])
+	if err != nil {
+		return nil, ErrInvalidFormat
+	}
+	entry.Timestamp = timestamp
+
+	// Module
+	module := matches[2]
+	entry.SetField("module", module)
+
+	// Level
+	level := strings.ToLower(matches[3])
+	entry.Level = apacheLevelToLogLevel(level)
+	entry.SetField("apache_level", level)
+
+	// PID
+	pid, _ := strconv.Atoi(matches[4])
+	entry.SetField("pid", pid)
+
+	// TID
+	tid, _ := strconv.Atoi(matches[5])
+	entry.SetField("tid", tid)
+
+	// Client (optional)
+	if matches[6] != "" {
+		client := matches[6]
+		entry.SetField("client", client)
+		// Extract just the IP if it includes port
+		if idx := strings.LastIndex(client, ":"); idx != -1 {
+			entry.SetField("client_ip", client[:idx])
+			if port, err := strconv.Atoi(client[idx+1:]); err == nil {
+				entry.SetField("client_port", port)
+			}
+		} else {
+			entry.SetField("client_ip", client)
+		}
+	}
+
+	// Message
+	entry.Message = matches[7]
+
+	p.ApplyOptions(entry, line)
+	return entry, nil
+}
+
+// parseApache22WithClient parses Apache 2.2 error log format with client.
+func (p *ApacheErrorParser) parseApache22WithClient(entry *models.LogEntry, line string, matches []string) (*models.LogEntry, error) {
+	// Parse timestamp
+	timestamp, err := parseApacheErrorTimestamp(matches[1])
+	if err != nil {
+		return nil, ErrInvalidFormat
+	}
+	entry.Timestamp = timestamp
+
+	// Level
+	level := strings.ToLower(matches[2])
+	entry.Level = apacheLevelToLogLevel(level)
+	entry.SetField("apache_level", level)
+
+	// Client
+	client := matches[3]
+	entry.SetField("client", client)
+	entry.SetField("client_ip", client)
+
+	// Message
+	entry.Message = matches[4]
+
+	p.ApplyOptions(entry, line)
+	return entry, nil
+}
+
+// parseApache22NoClient parses Apache 2.2 error log format without client.
+func (p *ApacheErrorParser) parseApache22NoClient(entry *models.LogEntry, line string, matches []string) (*models.LogEntry, error) {
+	// Parse timestamp
+	timestamp, err := parseApacheErrorTimestamp(matches[1])
+	if err != nil {
+		return nil, ErrInvalidFormat
+	}
+	entry.Timestamp = timestamp
+
+	// Level
+	level := strings.ToLower(matches[2])
+	entry.Level = apacheLevelToLogLevel(level)
+	entry.SetField("apache_level", level)
+
+	// Message
+	entry.Message = matches[3]
+
+	p.ApplyOptions(entry, line)
+	return entry, nil
+}
+
+// parseApacheErrorTimestamp parses Apache error log timestamp in various formats.
+func parseApacheErrorTimestamp(s string) (time.Time, error) {
+	// Try Apache 2.4+ format first (with microseconds)
+	if t, err := time.Parse(apache24ErrorTimeFormat, s); err == nil {
+		return t, nil
+	}
+	// Try Apache 2.2 format (without microseconds)
+	if t, err := time.Parse(apache22ErrorTimeFormat, s); err == nil {
+		return t, nil
+	}
+	// Try common variations
+	formats := []string{
+		"Mon Jan 2 15:04:05.000000 2006",
+		"Mon Jan 2 15:04:05 2006",
+		"Mon Jan _2 15:04:05.000000 2006",
+		"Mon Jan _2 15:04:05 2006",
+	}
+	for _, format := range formats {
+		if t, err := time.Parse(format, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, ErrInvalidFormat
+}
+
+// apacheLevelToLogLevel converts Apache log level to models.LogLevel.
+func apacheLevelToLogLevel(level string) models.LogLevel {
+	switch level {
+	case "trace1", "trace2", "trace3", "trace4", "trace5", "trace6", "trace7", "trace8", "debug":
+		return models.LevelDebug
+	case "info", "notice":
+		return models.LevelInfo
+	case "warn":
+		return models.LevelWarning
+	case "error":
+		return models.LevelError
+	case "crit", "alert", "emerg":
+		return models.LevelFatal
+	default:
+		return models.LevelUnknown
+	}
+}
+
+// Name returns the parser name.
+func (p *ApacheErrorParser) Name() string {
+	return "apache-error"
+}
+
+// Type returns the log type this parser handles.
+func (p *ApacheErrorParser) Type() models.LogType {
+	return models.LogTypeApache
+}
+
+// CanParse returns true if the line looks like an Apache error log.
+func (p *ApacheErrorParser) CanParse(line string) bool {
+	return p.regex24.MatchString(line) || p.regex22.MatchString(line) || p.regex22NoClient.MatchString(line)
+}

--- a/internal/parser/apache_test.go
+++ b/internal/parser/apache_test.go
@@ -1,0 +1,645 @@
+package parser
+
+import (
+	"testing"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+// TestApacheAccessParser_Parse tests the Apache access log parser.
+func TestApacheAccessParser_Parse(t *testing.T) {
+	parser := NewApacheAccessParser(nil)
+
+	tests := []struct {
+		name           string
+		line           string
+		expectError    bool
+		expectedLevel  models.LogLevel
+		expectedStatus int
+		expectedMethod string
+		expectedURI    string
+	}{
+		{
+			name:           "combined format - successful GET",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /index.html HTTP/1.1" 200 2326 "http://example.com/" "Mozilla/5.0"`,
+			expectError:    false,
+			expectedLevel:  models.LevelInfo,
+			expectedStatus: 200,
+			expectedMethod: "GET",
+			expectedURI:    "/index.html",
+		},
+		{
+			name:           "combined format - POST with auth user",
+			line:           `192.168.1.1 - admin [10/Oct/2024:13:55:36 -0700] "POST /api/users HTTP/1.1" 201 156 "-" "curl/7.64.1"`,
+			expectError:    false,
+			expectedLevel:  models.LevelInfo,
+			expectedStatus: 201,
+			expectedMethod: "POST",
+			expectedURI:    "/api/users",
+		},
+		{
+			name:           "combined format - with ident",
+			line:           `192.168.1.1 identd admin [10/Oct/2024:13:55:36 -0700] "GET /page HTTP/1.1" 200 512 "-" "Mozilla/5.0"`,
+			expectError:    false,
+			expectedLevel:  models.LevelInfo,
+			expectedStatus: 200,
+			expectedMethod: "GET",
+			expectedURI:    "/page",
+		},
+		{
+			name:           "combined format - 404 error",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /missing.html HTTP/1.1" 404 162 "-" "Mozilla/5.0"`,
+			expectError:    false,
+			expectedLevel:  models.LevelWarning,
+			expectedStatus: 404,
+			expectedMethod: "GET",
+			expectedURI:    "/missing.html",
+		},
+		{
+			name:           "combined format - 500 server error",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /error HTTP/1.1" 500 0 "-" "Mozilla/5.0"`,
+			expectError:    false,
+			expectedLevel:  models.LevelError,
+			expectedStatus: 500,
+			expectedMethod: "GET",
+			expectedURI:    "/error",
+		},
+		{
+			name:           "combined format - 503 service unavailable",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /api HTTP/1.1" 503 0 "-" "curl/7.64.1"`,
+			expectError:    false,
+			expectedLevel:  models.LevelError,
+			expectedStatus: 503,
+			expectedMethod: "GET",
+			expectedURI:    "/api",
+		},
+		{
+			name:           "combined format - no bytes sent (dash)",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "HEAD /status HTTP/1.1" 204 - "-" "curl/7.64.1"`,
+			expectError:    false,
+			expectedLevel:  models.LevelInfo,
+			expectedStatus: 204,
+			expectedMethod: "HEAD",
+			expectedURI:    "/status",
+		},
+		{
+			name:           "common format - no referer/user-agent",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /index.html HTTP/1.1" 200 2326`,
+			expectError:    false,
+			expectedLevel:  models.LevelInfo,
+			expectedStatus: 200,
+			expectedMethod: "GET",
+			expectedURI:    "/index.html",
+		},
+		{
+			name:           "common format - no bytes (dash)",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /index.html HTTP/1.1" 304 -`,
+			expectError:    false,
+			expectedLevel:  models.LevelInfo,
+			expectedStatus: 304,
+			expectedMethod: "GET",
+			expectedURI:    "/index.html",
+		},
+		{
+			name:           "PUT request",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "PUT /api/resource HTTP/1.1" 200 100 "-" "curl/7.64.1"`,
+			expectError:    false,
+			expectedLevel:  models.LevelInfo,
+			expectedStatus: 200,
+			expectedMethod: "PUT",
+			expectedURI:    "/api/resource",
+		},
+		{
+			name:           "DELETE request",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "DELETE /api/resource/123 HTTP/1.1" 204 0 "-" "curl/7.64.1"`,
+			expectError:    false,
+			expectedLevel:  models.LevelInfo,
+			expectedStatus: 204,
+			expectedMethod: "DELETE",
+			expectedURI:    "/api/resource/123",
+		},
+		{
+			name:           "URL with query string",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /search?q=test&page=1 HTTP/1.1" 200 1500 "-" "Mozilla/5.0"`,
+			expectError:    false,
+			expectedLevel:  models.LevelInfo,
+			expectedStatus: 200,
+			expectedMethod: "GET",
+			expectedURI:    "/search?q=test&page=1",
+		},
+		{
+			name:           "301 redirect",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /old-page HTTP/1.1" 301 0 "-" "Mozilla/5.0"`,
+			expectError:    false,
+			expectedLevel:  models.LevelInfo,
+			expectedStatus: 301,
+			expectedMethod: "GET",
+			expectedURI:    "/old-page",
+		},
+		{
+			name:           "401 unauthorized",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /admin HTTP/1.1" 401 0 "-" "Mozilla/5.0"`,
+			expectError:    false,
+			expectedLevel:  models.LevelWarning,
+			expectedStatus: 401,
+			expectedMethod: "GET",
+			expectedURI:    "/admin",
+		},
+		{
+			name:           "403 forbidden",
+			line:           `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /secret HTTP/1.1" 403 0 "-" "Mozilla/5.0"`,
+			expectError:    false,
+			expectedLevel:  models.LevelWarning,
+			expectedStatus: 403,
+			expectedMethod: "GET",
+			expectedURI:    "/secret",
+		},
+		{
+			name:        "invalid format",
+			line:        "this is not a valid log line",
+			expectError: true,
+		},
+		{
+			name:        "empty line",
+			line:        "",
+			expectError: true,
+		},
+		{
+			name:        "partial log line",
+			line:        `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700]`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry, err := parser.Parse(tt.line)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Parse(%q): expected error, got nil", tt.line)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Parse(%q): unexpected error: %v", tt.line, err)
+				return
+			}
+
+			if entry.Level != tt.expectedLevel {
+				t.Errorf("Parse(%q): expected level %v, got %v", tt.line, tt.expectedLevel, entry.Level)
+			}
+
+			if entry.GetFieldInt("status") != tt.expectedStatus {
+				t.Errorf("Parse(%q): expected status %d, got %d", tt.line, tt.expectedStatus, entry.GetFieldInt("status"))
+			}
+
+			if entry.GetFieldString("method") != tt.expectedMethod {
+				t.Errorf("Parse(%q): expected method %s, got %s", tt.line, tt.expectedMethod, entry.GetFieldString("method"))
+			}
+
+			if entry.GetFieldString("request_uri") != tt.expectedURI {
+				t.Errorf("Parse(%q): expected URI %s, got %s", tt.line, tt.expectedURI, entry.GetFieldString("request_uri"))
+			}
+
+			if entry.Type != models.LogTypeApache {
+				t.Errorf("Parse(%q): expected type %v, got %v", tt.line, models.LogTypeApache, entry.Type)
+			}
+		})
+	}
+}
+
+// TestApacheAccessParser_CombinedFields tests that combined format extracts all fields.
+func TestApacheAccessParser_CombinedFields(t *testing.T) {
+	parser := NewApacheAccessParser(nil)
+	line := `192.168.1.1 identd john [10/Oct/2024:13:55:36 -0700] "GET /index.html HTTP/1.1" 200 2326 "http://example.com/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"`
+
+	entry, err := parser.Parse(line)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	if entry.GetFieldString("remote_host") != "192.168.1.1" {
+		t.Errorf("Expected remote_host '192.168.1.1', got '%s'", entry.GetFieldString("remote_host"))
+	}
+
+	if entry.GetFieldString("ident") != "identd" {
+		t.Errorf("Expected ident 'identd', got '%s'", entry.GetFieldString("ident"))
+	}
+
+	if entry.GetFieldString("remote_user") != "john" {
+		t.Errorf("Expected remote_user 'john', got '%s'", entry.GetFieldString("remote_user"))
+	}
+
+	if entry.GetFieldString("protocol") != "HTTP/1.1" {
+		t.Errorf("Expected protocol 'HTTP/1.1', got '%s'", entry.GetFieldString("protocol"))
+	}
+
+	if entry.GetFieldInt("bytes_sent") != 2326 {
+		t.Errorf("Expected bytes_sent 2326, got %d", entry.GetFieldInt("bytes_sent"))
+	}
+
+	if entry.GetFieldString("http_referer") != "http://example.com/" {
+		t.Errorf("Expected http_referer 'http://example.com/', got '%s'", entry.GetFieldString("http_referer"))
+	}
+
+	if entry.GetFieldString("http_user_agent") != "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" {
+		t.Errorf("Expected http_user_agent, got '%s'", entry.GetFieldString("http_user_agent"))
+	}
+
+	// Verify timestamp parsing
+	expectedTime := time.Date(2024, 10, 10, 13, 55, 36, 0, time.FixedZone("", -7*60*60))
+	if !entry.Timestamp.Equal(expectedTime) {
+		t.Errorf("Expected timestamp %v, got %v", expectedTime, entry.Timestamp)
+	}
+}
+
+// TestApacheAccessParser_CanParse tests auto-detection.
+func TestApacheAccessParser_CanParse(t *testing.T) {
+	parser := NewApacheAccessParser(nil)
+
+	tests := []struct {
+		line     string
+		expected bool
+	}{
+		{`192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /index.html HTTP/1.1" 200 2326 "-" "Mozilla/5.0"`, true},
+		{`192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /index.html HTTP/1.1" 200 2326`, true},
+		{`[Sat Oct 10 14:32:52.123456 2020] [core:error] [pid 12345:tid 123456789] AH00124: test`, false},
+		{"invalid line", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		got := parser.CanParse(tt.line)
+		if got != tt.expected {
+			t.Errorf("CanParse(%q): expected %v, got %v", tt.line, tt.expected, got)
+		}
+	}
+}
+
+// TestApacheAccessParser_Name tests the parser name.
+func TestApacheAccessParser_Name(t *testing.T) {
+	parser := NewApacheAccessParser(nil)
+	if parser.Name() != "apache-access" {
+		t.Errorf("Expected name 'apache-access', got '%s'", parser.Name())
+	}
+}
+
+// TestApacheAccessParser_Type tests the parser type.
+func TestApacheAccessParser_Type(t *testing.T) {
+	parser := NewApacheAccessParser(nil)
+	if parser.Type() != models.LogTypeApache {
+		t.Errorf("Expected type %v, got %v", models.LogTypeApache, parser.Type())
+	}
+}
+
+// TestApacheAccessParser_Options tests that parser options are applied.
+func TestApacheAccessParser_Options(t *testing.T) {
+	opts := &ParserOptions{
+		IncludeRaw: true,
+		Source:     "apache-server-1",
+		Labels: map[string]string{
+			"env": "production",
+		},
+	}
+
+	parser := NewApacheAccessParser(opts)
+	line := `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /index.html HTTP/1.1" 200 2326 "-" "Mozilla/5.0"`
+
+	entry, err := parser.Parse(line)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	if entry.Raw != line {
+		t.Errorf("Expected raw line to be included")
+	}
+
+	if entry.Source != "apache-server-1" {
+		t.Errorf("Expected source 'apache-server-1', got '%s'", entry.Source)
+	}
+
+	if entry.GetLabel("env") != "production" {
+		t.Errorf("Expected label env='production', got '%s'", entry.GetLabel("env"))
+	}
+}
+
+// TestApacheErrorParser_Parse tests the Apache error log parser.
+func TestApacheErrorParser_Parse(t *testing.T) {
+	parser := NewApacheErrorParser(nil)
+
+	tests := []struct {
+		name          string
+		line          string
+		expectError   bool
+		expectedLevel models.LogLevel
+		expectedMsg   string
+	}{
+		{
+			name:          "Apache 2.4 - error with client",
+			line:          `[Sat Oct 10 14:32:52.123456 2020] [core:error] [pid 12345:tid 123456789] [client 192.168.1.1:56789] AH00124: Request exceeded the limit`,
+			expectError:   false,
+			expectedLevel: models.LevelError,
+			expectedMsg:   "AH00124: Request exceeded the limit",
+		},
+		{
+			name:          "Apache 2.4 - notice without client",
+			line:          `[Sat Oct 10 14:32:52.123456 2020] [mpm_prefork:notice] [pid 12345:tid 123456789] AH00163: Apache/2.4.41 configured`,
+			expectError:   false,
+			expectedLevel: models.LevelInfo,
+			expectedMsg:   "AH00163: Apache/2.4.41 configured",
+		},
+		{
+			name:          "Apache 2.4 - warn level",
+			line:          `[Sat Oct 10 14:32:52.123456 2020] [ssl:warn] [pid 12345:tid 123456789] AH01909: warning message`,
+			expectError:   false,
+			expectedLevel: models.LevelWarning,
+			expectedMsg:   "AH01909: warning message",
+		},
+		{
+			name:          "Apache 2.4 - debug level",
+			line:          `[Sat Oct 10 14:32:52.123456 2020] [core:debug] [pid 12345:tid 123456789] debug message here`,
+			expectError:   false,
+			expectedLevel: models.LevelDebug,
+			expectedMsg:   "debug message here",
+		},
+		{
+			name:          "Apache 2.4 - info level",
+			line:          `[Sat Oct 10 14:32:52.123456 2020] [core:info] [pid 12345:tid 123456789] informational message`,
+			expectError:   false,
+			expectedLevel: models.LevelInfo,
+			expectedMsg:   "informational message",
+		},
+		{
+			name:          "Apache 2.4 - crit level",
+			line:          `[Sat Oct 10 14:32:52.123456 2020] [core:crit] [pid 12345:tid 123456789] critical error occurred`,
+			expectError:   false,
+			expectedLevel: models.LevelFatal,
+			expectedMsg:   "critical error occurred",
+		},
+		{
+			name:          "Apache 2.4 - alert level",
+			line:          `[Sat Oct 10 14:32:52.123456 2020] [core:alert] [pid 12345:tid 123456789] alert message`,
+			expectError:   false,
+			expectedLevel: models.LevelFatal,
+			expectedMsg:   "alert message",
+		},
+		{
+			name:          "Apache 2.4 - emerg level",
+			line:          `[Sat Oct 10 14:32:52.123456 2020] [core:emerg] [pid 12345:tid 123456789] emergency situation`,
+			expectError:   false,
+			expectedLevel: models.LevelFatal,
+			expectedMsg:   "emergency situation",
+		},
+		{
+			name:          "Apache 2.2 - error with client",
+			line:          `[Sat Oct 10 14:32:52 2020] [error] [client 192.168.1.1] File does not exist: /var/www/html/missing.html`,
+			expectError:   false,
+			expectedLevel: models.LevelError,
+			expectedMsg:   "File does not exist: /var/www/html/missing.html",
+		},
+		{
+			name:          "Apache 2.2 - notice without client",
+			line:          `[Sat Oct 10 14:32:52 2020] [notice] Apache/2.2.22 configured -- resuming normal operations`,
+			expectError:   false,
+			expectedLevel: models.LevelInfo,
+			expectedMsg:   "Apache/2.2.22 configured -- resuming normal operations",
+		},
+		{
+			name:          "Apache 2.2 - warn level",
+			line:          `[Sat Oct 10 14:32:52 2020] [warn] warning message here`,
+			expectError:   false,
+			expectedLevel: models.LevelWarning,
+			expectedMsg:   "warning message here",
+		},
+		{
+			name:        "invalid format",
+			line:        "this is not a valid error log line",
+			expectError: true,
+		},
+		{
+			name:        "empty line",
+			line:        "",
+			expectError: true,
+		},
+		{
+			name:        "access log format (should fail)",
+			line:        `192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /index.html HTTP/1.1" 200 2326`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry, err := parser.Parse(tt.line)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Parse(%q): expected error, got nil", tt.line)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Parse(%q): unexpected error: %v", tt.line, err)
+				return
+			}
+
+			if entry.Level != tt.expectedLevel {
+				t.Errorf("Parse(%q): expected level %v, got %v", tt.line, tt.expectedLevel, entry.Level)
+			}
+
+			if entry.Message != tt.expectedMsg {
+				t.Errorf("Parse(%q): expected message %q, got %q", tt.line, tt.expectedMsg, entry.Message)
+			}
+
+			if entry.Type != models.LogTypeApache {
+				t.Errorf("Parse(%q): expected type %v, got %v", tt.line, models.LogTypeApache, entry.Type)
+			}
+		})
+	}
+}
+
+// TestApacheErrorParser_Apache24Fields tests that all fields are extracted correctly for Apache 2.4+.
+func TestApacheErrorParser_Apache24Fields(t *testing.T) {
+	parser := NewApacheErrorParser(nil)
+	line := `[Sat Oct 10 14:32:52.123456 2020] [core:error] [pid 12345:tid 67890] [client 192.168.1.100:54321] AH00124: test error`
+
+	entry, err := parser.Parse(line)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	if entry.GetFieldString("module") != "core" {
+		t.Errorf("Expected module 'core', got '%s'", entry.GetFieldString("module"))
+	}
+
+	if entry.GetFieldInt("pid") != 12345 {
+		t.Errorf("Expected pid 12345, got %d", entry.GetFieldInt("pid"))
+	}
+
+	if entry.GetFieldInt("tid") != 67890 {
+		t.Errorf("Expected tid 67890, got %d", entry.GetFieldInt("tid"))
+	}
+
+	if entry.GetFieldString("client") != "192.168.1.100:54321" {
+		t.Errorf("Expected client '192.168.1.100:54321', got '%s'", entry.GetFieldString("client"))
+	}
+
+	if entry.GetFieldString("client_ip") != "192.168.1.100" {
+		t.Errorf("Expected client_ip '192.168.1.100', got '%s'", entry.GetFieldString("client_ip"))
+	}
+
+	if entry.GetFieldInt("client_port") != 54321 {
+		t.Errorf("Expected client_port 54321, got %d", entry.GetFieldInt("client_port"))
+	}
+
+	if entry.GetFieldString("apache_level") != "error" {
+		t.Errorf("Expected apache_level 'error', got '%s'", entry.GetFieldString("apache_level"))
+	}
+
+	// Verify timestamp parsing
+	expectedTime := time.Date(2020, 10, 10, 14, 32, 52, 123456000, time.UTC)
+	if !entry.Timestamp.Equal(expectedTime) {
+		t.Errorf("Expected timestamp %v, got %v", expectedTime, entry.Timestamp)
+	}
+}
+
+// TestApacheErrorParser_Apache22Fields tests that all fields are extracted correctly for Apache 2.2.
+func TestApacheErrorParser_Apache22Fields(t *testing.T) {
+	parser := NewApacheErrorParser(nil)
+	line := `[Sat Oct 10 14:32:52 2020] [error] [client 192.168.1.100] File does not exist: /var/www/test`
+
+	entry, err := parser.Parse(line)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	if entry.GetFieldString("client") != "192.168.1.100" {
+		t.Errorf("Expected client '192.168.1.100', got '%s'", entry.GetFieldString("client"))
+	}
+
+	if entry.GetFieldString("client_ip") != "192.168.1.100" {
+		t.Errorf("Expected client_ip '192.168.1.100', got '%s'", entry.GetFieldString("client_ip"))
+	}
+
+	if entry.GetFieldString("apache_level") != "error" {
+		t.Errorf("Expected apache_level 'error', got '%s'", entry.GetFieldString("apache_level"))
+	}
+
+	// Verify timestamp parsing
+	expectedTime := time.Date(2020, 10, 10, 14, 32, 52, 0, time.UTC)
+	if !entry.Timestamp.Equal(expectedTime) {
+		t.Errorf("Expected timestamp %v, got %v", expectedTime, entry.Timestamp)
+	}
+}
+
+// TestApacheErrorParser_NoClient tests parsing Apache 2.4 logs without client info.
+func TestApacheErrorParser_NoClient(t *testing.T) {
+	parser := NewApacheErrorParser(nil)
+	line := `[Sat Oct 10 14:32:52.123456 2020] [mpm_prefork:notice] [pid 12345:tid 67890] AH00163: Apache configured`
+
+	entry, err := parser.Parse(line)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	// Client should not be set
+	if _, ok := entry.GetField("client"); ok {
+		t.Error("Expected client to not be set")
+	}
+
+	if entry.GetFieldString("module") != "mpm_prefork" {
+		t.Errorf("Expected module 'mpm_prefork', got '%s'", entry.GetFieldString("module"))
+	}
+}
+
+// TestApacheErrorParser_CanParse tests auto-detection.
+func TestApacheErrorParser_CanParse(t *testing.T) {
+	parser := NewApacheErrorParser(nil)
+
+	tests := []struct {
+		line     string
+		expected bool
+	}{
+		{`[Sat Oct 10 14:32:52.123456 2020] [core:error] [pid 12345:tid 67890] test message`, true},
+		{`[Sat Oct 10 14:32:52.123456 2020] [mpm_prefork:notice] [pid 12345:tid 67890] [client 1.2.3.4:5678] test`, true},
+		{`[Sat Oct 10 14:32:52 2020] [error] [client 192.168.1.1] test message`, true},
+		{`[Sat Oct 10 14:32:52 2020] [notice] test message`, true},
+		{`192.168.1.1 - - [10/Oct/2024:13:55:36 -0700] "GET /index.html HTTP/1.1" 200 2326`, false},
+		{"invalid line", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		got := parser.CanParse(tt.line)
+		if got != tt.expected {
+			t.Errorf("CanParse(%q): expected %v, got %v", tt.line, tt.expected, got)
+		}
+	}
+}
+
+// TestApacheErrorParser_Name tests the parser name.
+func TestApacheErrorParser_Name(t *testing.T) {
+	parser := NewApacheErrorParser(nil)
+	if parser.Name() != "apache-error" {
+		t.Errorf("Expected name 'apache-error', got '%s'", parser.Name())
+	}
+}
+
+// TestApacheErrorParser_Type tests the parser type.
+func TestApacheErrorParser_Type(t *testing.T) {
+	parser := NewApacheErrorParser(nil)
+	if parser.Type() != models.LogTypeApache {
+		t.Errorf("Expected type %v, got %v", models.LogTypeApache, parser.Type())
+	}
+}
+
+// TestApacheErrorParser_Options tests that parser options are applied.
+func TestApacheErrorParser_Options(t *testing.T) {
+	opts := &ParserOptions{
+		IncludeRaw: true,
+		Source:     "apache-error-log",
+		Labels: map[string]string{
+			"env": "staging",
+		},
+	}
+
+	parser := NewApacheErrorParser(opts)
+	line := `[Sat Oct 10 14:32:52.123456 2020] [core:error] [pid 12345:tid 67890] test error`
+
+	entry, err := parser.Parse(line)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	if entry.Raw != line {
+		t.Errorf("Expected raw line to be included")
+	}
+
+	if entry.Source != "apache-error-log" {
+		t.Errorf("Expected source 'apache-error-log', got '%s'", entry.Source)
+	}
+
+	if entry.GetLabel("env") != "staging" {
+		t.Errorf("Expected label env='staging', got '%s'", entry.GetLabel("env"))
+	}
+}
+
+// TestApacheErrorParser_TraceLevels tests trace levels are recognized.
+func TestApacheErrorParser_TraceLevels(t *testing.T) {
+	parser := NewApacheErrorParser(nil)
+
+	for i := 1; i <= 8; i++ {
+		line := `[Sat Oct 10 14:32:52.123456 2020] [core:trace` + string(rune('0'+i)) + `] [pid 12345:tid 67890] trace message`
+		entry, err := parser.Parse(line)
+		if err != nil {
+			t.Fatalf("Parse trace%d error: %v", i, err)
+		}
+		if entry.Level != models.LevelDebug {
+			t.Errorf("trace%d: expected level debug, got %v", i, entry.Level)
+		}
+	}
+}

--- a/internal/parser/init.go
+++ b/internal/parser/init.go
@@ -8,4 +8,10 @@ func init() {
 	// return the same LogType (nginx). The error parser can be explicitly
 	// requested via the CLI with "nginx-error".
 	Register(NewNginxAccessParser(nil))
+
+	// Register Apache access parser for auto-detection
+	// Note: We only register the access parser by default since both parsers
+	// return the same LogType (apache). The error parser can be explicitly
+	// requested via the CLI with "apache-error".
+	Register(NewApacheAccessParser(nil))
 }


### PR DESCRIPTION
Add Apache access and error log parsers supporting multiple log formats:

- ApacheAccessParser: parses both combined and common log formats
- ApacheErrorParser: supports Apache 2.4+ and Apache 2.2 formats

Features:
- HTTP status code to log level mapping (5xx=error, 4xx=warning)
- Extraction of key fields (remote_host, method, uri, status, bytes)
- Auto-detection via CanParse for format discovery
- Full parser options support (labels, source, raw line inclusion)

Also fixes go.mod to use installed Go version (1.24.7).