### PR TITLE
Implement Milestone 9: Email Notifications

### DIFF
--- a/internal/notifier/email.go
+++ b/internal/notifier/email.go
@@ -1,0 +1,247 @@
+package notifier
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/smtp"
+	"strings"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/alerting"
+)
+
+// EmailConfig holds SMTP configuration.
+type EmailConfig struct {
+	Host       string   // SMTP server host
+	Port       int      // SMTP server port (465 for implicit TLS, 587 for STARTTLS)
+	Username   string   // SMTP username (optional)
+	Password   string   // SMTP password (optional)
+	From       string   // From address
+	Recipients []string // Email recipients
+}
+
+// Validate validates the email configuration.
+func (c *EmailConfig) Validate() error {
+	if c.Host == "" {
+		return fmt.Errorf("SMTP host is required")
+	}
+	if c.Port == 0 {
+		return fmt.Errorf("SMTP port is required")
+	}
+	if c.From == "" {
+		return fmt.Errorf("from address is required")
+	}
+	if len(c.Recipients) == 0 {
+		return fmt.Errorf("at least one recipient is required")
+	}
+	return nil
+}
+
+// EmailNotifier sends alerts via email.
+type EmailNotifier struct {
+	config    EmailConfig
+	templates *Templates
+}
+
+// NewEmailNotifier creates a new email notifier.
+func NewEmailNotifier(config EmailConfig) (*EmailNotifier, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid email config: %w", err)
+	}
+
+	templates, err := LoadTemplates()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load templates: %w", err)
+	}
+
+	return &EmailNotifier{
+		config:    config,
+		templates: templates,
+	}, nil
+}
+
+// Name returns "email".
+func (e *EmailNotifier) Name() string {
+	return "email"
+}
+
+// Send sends an alert to all configured recipients.
+func (e *EmailNotifier) Send(ctx context.Context, alert *alerting.Alert) error {
+	// Convert alert to template data
+	data := AlertToTemplateData(alert)
+
+	// Render templates
+	htmlBody, err := e.templates.RenderHTML(data)
+	if err != nil {
+		return fmt.Errorf("failed to render HTML template: %w", err)
+	}
+
+	plainBody, err := e.templates.RenderPlain(data)
+	if err != nil {
+		return fmt.Errorf("failed to render plain template: %w", err)
+	}
+
+	// Build subject
+	subject := fmt.Sprintf("[%s] BlazeLog Alert: %s", strings.ToUpper(string(alert.Severity)), alert.RuleName)
+
+	// Build message
+	msg := e.buildMIMEMessage(subject, plainBody, htmlBody)
+
+	// Send email
+	return e.sendMail(ctx, msg)
+}
+
+// Close is a no-op for email notifier.
+func (e *EmailNotifier) Close() error {
+	return nil
+}
+
+// buildMIMEMessage builds a MIME multipart message with HTML and plain text.
+func (e *EmailNotifier) buildMIMEMessage(subject, plainBody, htmlBody string) []byte {
+	boundary := fmt.Sprintf("----=_Part_%d", time.Now().UnixNano())
+
+	var msg strings.Builder
+
+	// Headers
+	msg.WriteString(fmt.Sprintf("From: %s\r\n", e.config.From))
+	msg.WriteString(fmt.Sprintf("To: %s\r\n", strings.Join(e.config.Recipients, ", ")))
+	msg.WriteString(fmt.Sprintf("Subject: %s\r\n", subject))
+	msg.WriteString("MIME-Version: 1.0\r\n")
+	msg.WriteString(fmt.Sprintf("Content-Type: multipart/alternative; boundary=\"%s\"\r\n", boundary))
+	msg.WriteString("\r\n")
+
+	// Plain text part
+	msg.WriteString(fmt.Sprintf("--%s\r\n", boundary))
+	msg.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+	msg.WriteString("Content-Transfer-Encoding: quoted-printable\r\n")
+	msg.WriteString("\r\n")
+	msg.WriteString(plainBody)
+	msg.WriteString("\r\n")
+
+	// HTML part
+	msg.WriteString(fmt.Sprintf("--%s\r\n", boundary))
+	msg.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
+	msg.WriteString("Content-Transfer-Encoding: quoted-printable\r\n")
+	msg.WriteString("\r\n")
+	msg.WriteString(htmlBody)
+	msg.WriteString("\r\n")
+
+	// End boundary
+	msg.WriteString(fmt.Sprintf("--%s--\r\n", boundary))
+
+	return []byte(msg.String())
+}
+
+// sendMail sends the email via SMTP.
+func (e *EmailNotifier) sendMail(ctx context.Context, msg []byte) error {
+	addr := fmt.Sprintf("%s:%d", e.config.Host, e.config.Port)
+
+	// Create TLS config
+	tlsConfig := &tls.Config{
+		ServerName: e.config.Host,
+	}
+
+	var client *smtp.Client
+	var err error
+
+	// Try to connect based on port
+	if e.config.Port == 465 {
+		// Implicit TLS (SMTPS)
+		client, err = e.connectImplicitTLS(addr, tlsConfig)
+	} else {
+		// STARTTLS (port 587 or 25)
+		client, err = e.connectSTARTTLS(ctx, addr, tlsConfig)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to connect to SMTP server: %w", err)
+	}
+	defer client.Close()
+
+	// Authenticate if credentials provided
+	if e.config.Username != "" && e.config.Password != "" {
+		auth := smtp.PlainAuth("", e.config.Username, e.config.Password, e.config.Host)
+		if err := client.Auth(auth); err != nil {
+			return fmt.Errorf("SMTP authentication failed: %w", err)
+		}
+	}
+
+	// Set sender
+	if err := client.Mail(e.extractEmail(e.config.From)); err != nil {
+		return fmt.Errorf("failed to set sender: %w", err)
+	}
+
+	// Set recipients
+	for _, rcpt := range e.config.Recipients {
+		if err := client.Rcpt(rcpt); err != nil {
+			return fmt.Errorf("failed to add recipient %s: %w", rcpt, err)
+		}
+	}
+
+	// Send message body
+	w, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("failed to start data: %w", err)
+	}
+
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("failed to write message: %w", err)
+	}
+
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("failed to close data: %w", err)
+	}
+
+	return client.Quit()
+}
+
+// connectImplicitTLS connects using implicit TLS (port 465).
+func (e *EmailNotifier) connectImplicitTLS(addr string, tlsConfig *tls.Config) (*smtp.Client, error) {
+	conn, err := tls.Dial("tcp", addr, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return smtp.NewClient(conn, e.config.Host)
+}
+
+// connectSTARTTLS connects using STARTTLS (port 587 or 25).
+func (e *EmailNotifier) connectSTARTTLS(ctx context.Context, addr string, tlsConfig *tls.Config) (*smtp.Client, error) {
+	// Use context-aware dialer
+	dialer := &net.Dialer{
+		Timeout: 30 * time.Second,
+	}
+
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := smtp.NewClient(conn, e.config.Host)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	// Try STARTTLS
+	if ok, _ := client.Extension("STARTTLS"); ok {
+		if err := client.StartTLS(tlsConfig); err != nil {
+			client.Close()
+			return nil, fmt.Errorf("STARTTLS failed: %w", err)
+		}
+	}
+
+	return client, nil
+}
+
+// extractEmail extracts the email address from a "Name <email>" format.
+func (e *EmailNotifier) extractEmail(addr string) string {
+	if start := strings.Index(addr, "<"); start != -1 {
+		if end := strings.Index(addr, ">"); end != -1 {
+			return addr[start+1 : end]
+		}
+	}
+	return addr
+}

--- a/internal/notifier/email_test.go
+++ b/internal/notifier/email_test.go
@@ -1,0 +1,548 @@
+package notifier
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/alerting"
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+func TestEmailConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  EmailConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "empty config",
+			config:  EmailConfig{},
+			wantErr: true,
+			errMsg:  "SMTP host is required",
+		},
+		{
+			name: "missing port",
+			config: EmailConfig{
+				Host: "smtp.example.com",
+			},
+			wantErr: true,
+			errMsg:  "SMTP port is required",
+		},
+		{
+			name: "missing from",
+			config: EmailConfig{
+				Host: "smtp.example.com",
+				Port: 587,
+			},
+			wantErr: true,
+			errMsg:  "from address is required",
+		},
+		{
+			name: "missing recipients",
+			config: EmailConfig{
+				Host: "smtp.example.com",
+				Port: 587,
+				From: "test@example.com",
+			},
+			wantErr: true,
+			errMsg:  "at least one recipient is required",
+		},
+		{
+			name: "valid config",
+			config: EmailConfig{
+				Host:       "smtp.example.com",
+				Port:       587,
+				From:       "test@example.com",
+				Recipients: []string{"admin@example.com"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errMsg)
+				} else if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tt.errMsg, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadTemplates(t *testing.T) {
+	templates, err := LoadTemplates()
+	if err != nil {
+		t.Fatalf("failed to load templates: %v", err)
+	}
+
+	if templates.html == nil {
+		t.Error("HTML template is nil")
+	}
+	if templates.plain == nil {
+		t.Error("plain template is nil")
+	}
+}
+
+func TestTemplatesRender(t *testing.T) {
+	templates, err := LoadTemplates()
+	if err != nil {
+		t.Fatalf("failed to load templates: %v", err)
+	}
+
+	data := TemplateData{
+		RuleName:      "Test Rule",
+		Description:   "Test description",
+		Severity:      "critical",
+		SeverityColor: "#d32f2f",
+		Message:       "Test message",
+		Timestamp:     "2024-01-15 10:30:00 UTC",
+		Count:         5,
+		Threshold:     3,
+		Window:        "5m",
+		TriggeringEntry: &LogEntryData{
+			Timestamp: "2024-01-15 10:30:00",
+			Level:     "error",
+			Message:   "Test log message",
+			FilePath:  "/var/log/test.log",
+		},
+		Labels: map[string]string{
+			"environment": "production",
+		},
+	}
+
+	// Test HTML rendering
+	html, err := templates.RenderHTML(data)
+	if err != nil {
+		t.Fatalf("failed to render HTML: %v", err)
+	}
+	if !strings.Contains(html, "Test Rule") {
+		t.Error("HTML missing rule name")
+	}
+	if !strings.Contains(html, "critical") {
+		t.Error("HTML missing severity")
+	}
+	if !strings.Contains(html, "Test message") {
+		t.Error("HTML missing message")
+	}
+
+	// Test plain rendering
+	plain, err := templates.RenderPlain(data)
+	if err != nil {
+		t.Fatalf("failed to render plain: %v", err)
+	}
+	if !strings.Contains(plain, "Test Rule") {
+		t.Error("plain missing rule name")
+	}
+	if !strings.Contains(plain, "CRITICAL") {
+		t.Error("plain missing severity (should be uppercased)")
+	}
+}
+
+func TestAlertToTemplateData(t *testing.T) {
+	now := time.Now()
+	alert := &alerting.Alert{
+		RuleName:    "High Error Rate",
+		Description: "More than 100 errors in 5 minutes",
+		Severity:    alerting.SeverityCritical,
+		Message:     "Threshold exceeded: 150 events in 5m (threshold: 100)",
+		Timestamp:   now,
+		Count:       150,
+		Threshold:   100,
+		Window:      "5m",
+		TriggeringEntry: &models.LogEntry{
+			Timestamp: now,
+			Level:     models.LogLevelError,
+			Message:   "Database connection failed",
+			FilePath:  "/var/log/app/error.log",
+		},
+		Labels: map[string]string{
+			"project": "ecommerce",
+		},
+	}
+
+	data := AlertToTemplateData(alert)
+
+	if data.RuleName != alert.RuleName {
+		t.Errorf("RuleName mismatch: got %q, want %q", data.RuleName, alert.RuleName)
+	}
+	if data.Severity != "critical" {
+		t.Errorf("Severity mismatch: got %q, want %q", data.Severity, "critical")
+	}
+	if data.SeverityColor != "#d32f2f" {
+		t.Errorf("SeverityColor mismatch: got %q, want %q", data.SeverityColor, "#d32f2f")
+	}
+	if data.Count != 150 {
+		t.Errorf("Count mismatch: got %d, want %d", data.Count, 150)
+	}
+	if data.TriggeringEntry == nil {
+		t.Error("TriggeringEntry is nil")
+	}
+	if data.TriggeringEntry.Level != "error" {
+		t.Errorf("TriggeringEntry.Level mismatch: got %q, want %q", data.TriggeringEntry.Level, "error")
+	}
+}
+
+func TestSeverityColor(t *testing.T) {
+	tests := []struct {
+		severity alerting.Severity
+		want     string
+	}{
+		{alerting.SeverityCritical, "#d32f2f"},
+		{alerting.SeverityHigh, "#f57c00"},
+		{alerting.SeverityMedium, "#fbc02d"},
+		{alerting.SeverityLow, "#388e3c"},
+		{alerting.Severity("unknown"), "#757575"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.severity), func(t *testing.T) {
+			got := severityColor(tt.severity)
+			if got != tt.want {
+				t.Errorf("severityColor(%q) = %q, want %q", tt.severity, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEmailNotifierName(t *testing.T) {
+	notifier := &EmailNotifier{}
+	if got := notifier.Name(); got != "email" {
+		t.Errorf("Name() = %q, want %q", got, "email")
+	}
+}
+
+func TestDispatcher(t *testing.T) {
+	dispatcher := NewDispatcher()
+
+	// Create a mock notifier
+	mock := &mockNotifier{name: "test", sent: make(chan *alerting.Alert, 1)}
+	dispatcher.Register(mock)
+
+	// Verify registration
+	n, ok := dispatcher.Get("test")
+	if !ok {
+		t.Fatal("notifier not found after registration")
+	}
+	if n.Name() != "test" {
+		t.Errorf("notifier name = %q, want %q", n.Name(), "test")
+	}
+
+	// Test dispatch
+	alert := &alerting.Alert{
+		RuleName: "Test",
+		Notify:   []string{"test"},
+	}
+
+	if err := dispatcher.Dispatch(context.Background(), alert); err != nil {
+		t.Fatalf("Dispatch failed: %v", err)
+	}
+
+	select {
+	case received := <-mock.sent:
+		if received.RuleName != "Test" {
+			t.Errorf("received alert rule name = %q, want %q", received.RuleName, "Test")
+		}
+	case <-time.After(time.Second):
+		t.Error("timeout waiting for alert")
+	}
+
+	// Test unregister
+	dispatcher.Unregister("test")
+	if _, ok := dispatcher.Get("test"); ok {
+		t.Error("notifier still exists after unregister")
+	}
+
+	// Test close
+	if err := dispatcher.Close(); err != nil {
+		t.Errorf("Close failed: %v", err)
+	}
+}
+
+func TestDispatcherDispatchAll(t *testing.T) {
+	dispatcher := NewDispatcher()
+
+	mock1 := &mockNotifier{name: "mock1", sent: make(chan *alerting.Alert, 1)}
+	mock2 := &mockNotifier{name: "mock2", sent: make(chan *alerting.Alert, 1)}
+	dispatcher.Register(mock1)
+	dispatcher.Register(mock2)
+
+	alert := &alerting.Alert{
+		RuleName: "Test",
+		Notify:   []string{}, // empty, should still dispatch to all with DispatchAll
+	}
+
+	if err := dispatcher.DispatchAll(context.Background(), alert); err != nil {
+		t.Fatalf("DispatchAll failed: %v", err)
+	}
+
+	// Both should receive
+	for _, mock := range []*mockNotifier{mock1, mock2} {
+		select {
+		case <-mock.sent:
+		case <-time.After(time.Second):
+			t.Errorf("timeout waiting for alert on %s", mock.name)
+		}
+	}
+}
+
+func TestBuildMIMEMessage(t *testing.T) {
+	notifier := &EmailNotifier{
+		config: EmailConfig{
+			From:       "BlazeLog <alerts@example.com>",
+			Recipients: []string{"admin@example.com", "ops@example.com"},
+		},
+	}
+
+	msg := notifier.buildMIMEMessage("Test Subject", "Plain body", "<html>HTML body</html>")
+	msgStr := string(msg)
+
+	// Check headers
+	if !strings.Contains(msgStr, "From: BlazeLog <alerts@example.com>") {
+		t.Error("message missing From header")
+	}
+	if !strings.Contains(msgStr, "To: admin@example.com, ops@example.com") {
+		t.Error("message missing To header")
+	}
+	if !strings.Contains(msgStr, "Subject: Test Subject") {
+		t.Error("message missing Subject header")
+	}
+	if !strings.Contains(msgStr, "MIME-Version: 1.0") {
+		t.Error("message missing MIME-Version header")
+	}
+	if !strings.Contains(msgStr, "multipart/alternative") {
+		t.Error("message missing multipart/alternative content type")
+	}
+
+	// Check bodies
+	if !strings.Contains(msgStr, "Plain body") {
+		t.Error("message missing plain text body")
+	}
+	if !strings.Contains(msgStr, "<html>HTML body</html>") {
+		t.Error("message missing HTML body")
+	}
+}
+
+func TestExtractEmail(t *testing.T) {
+	notifier := &EmailNotifier{}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"test@example.com", "test@example.com"},
+		{"Test User <test@example.com>", "test@example.com"},
+		{"BlazeLog Alerts <alerts@example.com>", "alerts@example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := notifier.extractEmail(tt.input)
+			if got != tt.want {
+				t.Errorf("extractEmail(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// mockNotifier is a test notifier that records sent alerts.
+type mockNotifier struct {
+	name string
+	sent chan *alerting.Alert
+}
+
+func (m *mockNotifier) Name() string {
+	return m.name
+}
+
+func (m *mockNotifier) Send(ctx context.Context, alert *alerting.Alert) error {
+	m.sent <- alert
+	return nil
+}
+
+func (m *mockNotifier) Close() error {
+	return nil
+}
+
+// mockSMTPServer creates a mock SMTP server for testing.
+type mockSMTPServer struct {
+	listener net.Listener
+	messages [][]byte
+	mu       sync.Mutex
+	wg       sync.WaitGroup
+}
+
+func newMockSMTPServer(t *testing.T) *mockSMTPServer {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+
+	server := &mockSMTPServer{
+		listener: listener,
+		messages: make([][]byte, 0),
+	}
+
+	server.wg.Add(1)
+	go server.serve(t)
+
+	return server
+}
+
+func (s *mockSMTPServer) serve(t *testing.T) {
+	defer s.wg.Done()
+
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return
+		}
+		go s.handleConnection(conn, t)
+	}
+}
+
+func (s *mockSMTPServer) handleConnection(conn net.Conn, t *testing.T) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	writer := bufio.NewWriter(conn)
+
+	// Send greeting
+	writer.WriteString("220 localhost SMTP Mock Server\r\n")
+	writer.Flush()
+
+	var dataMode bool
+	var messageData []byte
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+
+		line = strings.TrimSpace(line)
+
+		if dataMode {
+			if line == "." {
+				dataMode = false
+				s.mu.Lock()
+				s.messages = append(s.messages, messageData)
+				s.mu.Unlock()
+				messageData = nil
+				writer.WriteString("250 OK\r\n")
+				writer.Flush()
+				continue
+			}
+			messageData = append(messageData, []byte(line+"\n")...)
+			continue
+		}
+
+		upperLine := strings.ToUpper(line)
+
+		switch {
+		case strings.HasPrefix(upperLine, "EHLO"), strings.HasPrefix(upperLine, "HELO"):
+			writer.WriteString("250-localhost\r\n")
+			writer.WriteString("250 OK\r\n")
+			writer.Flush()
+		case strings.HasPrefix(upperLine, "MAIL FROM"):
+			writer.WriteString("250 OK\r\n")
+			writer.Flush()
+		case strings.HasPrefix(upperLine, "RCPT TO"):
+			writer.WriteString("250 OK\r\n")
+			writer.Flush()
+		case upperLine == "DATA":
+			writer.WriteString("354 Start mail input\r\n")
+			writer.Flush()
+			dataMode = true
+		case upperLine == "QUIT":
+			writer.WriteString("221 Bye\r\n")
+			writer.Flush()
+			return
+		default:
+			writer.WriteString("500 Unknown command\r\n")
+			writer.Flush()
+		}
+	}
+}
+
+func (s *mockSMTPServer) addr() string {
+	return s.listener.Addr().String()
+}
+
+func (s *mockSMTPServer) close() {
+	s.listener.Close()
+	s.wg.Wait()
+}
+
+func (s *mockSMTPServer) getMessages() [][]byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([][]byte, len(s.messages))
+	copy(result, s.messages)
+	return result
+}
+
+func TestEmailNotifierSendWithMockSMTP(t *testing.T) {
+	server := newMockSMTPServer(t)
+	defer server.close()
+
+	// Parse address
+	host, portStr, _ := net.SplitHostPort(server.addr())
+	var port int
+	_, _ = net.LookupPort("tcp", portStr)
+	// Manual parse since port is numeric
+	for _, c := range portStr {
+		port = port*10 + int(c-'0')
+	}
+
+	config := EmailConfig{
+		Host:       host,
+		Port:       port,
+		From:       "test@example.com",
+		Recipients: []string{"admin@example.com"},
+	}
+
+	notifier, err := NewEmailNotifier(config)
+	if err != nil {
+		t.Fatalf("failed to create notifier: %v", err)
+	}
+
+	alert := &alerting.Alert{
+		RuleName:    "Test Alert",
+		Description: "Test description",
+		Severity:    alerting.SeverityHigh,
+		Message:     "Test message",
+		Timestamp:   time.Now(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := notifier.Send(ctx, alert); err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	// Wait a bit for message to be processed
+	time.Sleep(100 * time.Millisecond)
+
+	messages := server.getMessages()
+	if len(messages) == 0 {
+		t.Fatal("no messages received by mock server")
+	}
+
+	msgStr := string(messages[0])
+	if !strings.Contains(msgStr, "Test Alert") {
+		t.Error("message doesn't contain alert name")
+	}
+}

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -1,0 +1,119 @@
+// Package notifier provides notification dispatching for alerts.
+package notifier
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/good-yellow-bee/blazelog/internal/alerting"
+)
+
+// Notifier is the interface for all notification channels.
+type Notifier interface {
+	// Name returns the notifier name (e.g., "email", "slack").
+	Name() string
+	// Send sends an alert notification.
+	Send(ctx context.Context, alert *alerting.Alert) error
+	// Close releases any resources.
+	Close() error
+}
+
+// Dispatcher manages multiple notifiers and routes alerts.
+type Dispatcher struct {
+	mu        sync.RWMutex
+	notifiers map[string]Notifier
+}
+
+// NewDispatcher creates a new notification dispatcher.
+func NewDispatcher() *Dispatcher {
+	return &Dispatcher{
+		notifiers: make(map[string]Notifier),
+	}
+}
+
+// Register adds a notifier to the dispatcher.
+func (d *Dispatcher) Register(n Notifier) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.notifiers[n.Name()] = n
+}
+
+// Unregister removes a notifier from the dispatcher.
+func (d *Dispatcher) Unregister(name string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.notifiers, name)
+}
+
+// Get returns a notifier by name.
+func (d *Dispatcher) Get(name string) (Notifier, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	n, ok := d.notifiers[name]
+	return n, ok
+}
+
+// Dispatch sends an alert to all notifiers specified in alert.Notify.
+// If alert.Notify is empty, the alert is not sent to any notifier.
+func (d *Dispatcher) Dispatch(ctx context.Context, alert *alerting.Alert) error {
+	if len(alert.Notify) == 0 {
+		return nil
+	}
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var errs []error
+	for _, name := range alert.Notify {
+		n, ok := d.notifiers[name]
+		if !ok {
+			continue
+		}
+		if err := n.Send(ctx, alert); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("notification errors: %v", errs)
+	}
+	return nil
+}
+
+// DispatchAll sends an alert to all registered notifiers regardless of alert.Notify.
+func (d *Dispatcher) DispatchAll(ctx context.Context, alert *alerting.Alert) error {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var errs []error
+	for name, n := range d.notifiers {
+		if err := n.Send(ctx, alert); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("notification errors: %v", errs)
+	}
+	return nil
+}
+
+// Close closes all registered notifiers.
+func (d *Dispatcher) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var errs []error
+	for name, n := range d.notifiers {
+		if err := n.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+		}
+	}
+	d.notifiers = make(map[string]Notifier)
+
+	if len(errs) > 0 {
+		return fmt.Errorf("close errors: %v", errs)
+	}
+	return nil
+}

--- a/internal/notifier/templates.go
+++ b/internal/notifier/templates.go
@@ -1,0 +1,129 @@
+package notifier
+
+import (
+	"bytes"
+	"embed"
+	"strings"
+	"text/template"
+
+	"github.com/good-yellow-bee/blazelog/internal/alerting"
+)
+
+//go:embed templates/*
+var templateFS embed.FS
+
+// Templates holds parsed email templates.
+type Templates struct {
+	html  *template.Template
+	plain *template.Template
+}
+
+// TemplateData contains data for template rendering.
+type TemplateData struct {
+	RuleName        string
+	Description     string
+	Severity        string
+	SeverityColor   string
+	Message         string
+	Timestamp       string
+	Count           int
+	Threshold       int
+	Window          string
+	TriggeringEntry *LogEntryData
+	Labels          map[string]string
+}
+
+// LogEntryData contains log entry data for templates.
+type LogEntryData struct {
+	Timestamp string
+	Level     string
+	Message   string
+	Source    string
+	FilePath  string
+}
+
+// LoadTemplates loads embedded email templates.
+func LoadTemplates() (*Templates, error) {
+	funcs := template.FuncMap{
+		"upper": strings.ToUpper,
+		"lower": strings.ToLower,
+	}
+
+	htmlTmpl, err := template.New("alert.html").Funcs(funcs).ParseFS(templateFS, "templates/alert.html")
+	if err != nil {
+		return nil, err
+	}
+
+	plainTmpl, err := template.New("alert.txt").Funcs(funcs).ParseFS(templateFS, "templates/alert.txt")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Templates{
+		html:  htmlTmpl,
+		plain: plainTmpl,
+	}, nil
+}
+
+// RenderHTML renders the HTML email body.
+func (t *Templates) RenderHTML(data TemplateData) (string, error) {
+	var buf bytes.Buffer
+	if err := t.html.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// RenderPlain renders the plain text email body.
+func (t *Templates) RenderPlain(data TemplateData) (string, error) {
+	var buf bytes.Buffer
+	if err := t.plain.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// severityColor returns the color for a severity level.
+func severityColor(severity alerting.Severity) string {
+	switch severity {
+	case alerting.SeverityCritical:
+		return "#d32f2f" // red
+	case alerting.SeverityHigh:
+		return "#f57c00" // orange
+	case alerting.SeverityMedium:
+		return "#fbc02d" // yellow
+	case alerting.SeverityLow:
+		return "#388e3c" // green
+	default:
+		return "#757575" // gray
+	}
+}
+
+// AlertToTemplateData converts an alert to template data.
+func AlertToTemplateData(alert *alerting.Alert) TemplateData {
+	data := TemplateData{
+		RuleName:      alert.RuleName,
+		Description:   alert.Description,
+		Severity:      string(alert.Severity),
+		SeverityColor: severityColor(alert.Severity),
+		Message:       alert.Message,
+		Timestamp:     alert.Timestamp.Format("2006-01-02 15:04:05 MST"),
+		Count:         alert.Count,
+		Threshold:     alert.Threshold,
+		Window:        alert.Window,
+		Labels:        alert.Labels,
+	}
+
+	if alert.TriggeringEntry != nil {
+		entry := alert.TriggeringEntry
+		data.TriggeringEntry = &LogEntryData{
+			Timestamp: entry.Timestamp.Format("2006-01-02 15:04:05"),
+			Level:     string(entry.Level),
+			Message:   entry.Message,
+			Source:    entry.Source,
+			FilePath:  entry.FilePath,
+		}
+	}
+
+	return data
+}

--- a/internal/notifier/templates/alert.html
+++ b/internal/notifier/templates/alert.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 0;
+        }
+        .header {
+            background: {{.SeverityColor}};
+            color: white;
+            padding: 20px;
+            border-radius: 4px 4px 0 0;
+        }
+        .header h1 {
+            margin: 0;
+            font-size: 18px;
+            font-weight: 600;
+        }
+        .severity {
+            text-transform: uppercase;
+            font-size: 12px;
+            font-weight: 700;
+            letter-spacing: 0.5px;
+            opacity: 0.9;
+        }
+        .content {
+            padding: 20px;
+            background: #fff;
+            border: 1px solid #e0e0e0;
+            border-top: none;
+            border-radius: 0 0 4px 4px;
+        }
+        .message {
+            font-size: 16px;
+            margin-bottom: 16px;
+            padding: 12px;
+            background: #f8f9fa;
+            border-radius: 4px;
+            border-left: 4px solid {{.SeverityColor}};
+        }
+        .details {
+            margin-bottom: 16px;
+        }
+        .details-row {
+            display: flex;
+            padding: 8px 0;
+            border-bottom: 1px solid #eee;
+        }
+        .details-label {
+            font-weight: 600;
+            width: 120px;
+            color: #666;
+        }
+        .details-value {
+            flex: 1;
+        }
+        .log-entry {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 16px;
+            border-radius: 4px;
+            font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+            font-size: 13px;
+            overflow-x: auto;
+            margin-top: 16px;
+        }
+        .log-entry-header {
+            color: #888;
+            font-size: 12px;
+            margin-bottom: 8px;
+        }
+        .log-level-error { color: #f44336; }
+        .log-level-warning { color: #ff9800; }
+        .log-level-info { color: #2196f3; }
+        .threshold-info {
+            background: #fff3e0;
+            border: 1px solid #ffcc80;
+            padding: 12px;
+            border-radius: 4px;
+            margin-top: 16px;
+        }
+        .threshold-count {
+            font-size: 24px;
+            font-weight: 700;
+            color: {{.SeverityColor}};
+        }
+        .footer {
+            padding: 16px 20px;
+            font-size: 12px;
+            color: #888;
+            text-align: center;
+            border-top: 1px solid #eee;
+        }
+        .labels {
+            margin-top: 16px;
+        }
+        .label {
+            display: inline-block;
+            background: #e8e8e8;
+            padding: 2px 8px;
+            border-radius: 3px;
+            font-size: 12px;
+            margin-right: 4px;
+            margin-bottom: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <div class="severity">{{.Severity}} Alert</div>
+        <h1>{{.RuleName}}</h1>
+    </div>
+    <div class="content">
+        <div class="message">{{.Message}}</div>
+
+        <div class="details">
+            <div class="details-row">
+                <div class="details-label">Time</div>
+                <div class="details-value">{{.Timestamp}}</div>
+            </div>
+            {{if .Description}}
+            <div class="details-row">
+                <div class="details-label">Description</div>
+                <div class="details-value">{{.Description}}</div>
+            </div>
+            {{end}}
+        </div>
+
+        {{if gt .Count 0}}
+        <div class="threshold-info">
+            <div>Threshold Alert</div>
+            <div><span class="threshold-count">{{.Count}}</span> events in {{.Window}}</div>
+            <div>Threshold: {{.Threshold}}</div>
+        </div>
+        {{end}}
+
+        {{if .TriggeringEntry}}
+        <div class="log-entry">
+            <div class="log-entry-header">Triggering Log Entry</div>
+            <div>
+                <span style="color: #888;">{{.TriggeringEntry.Timestamp}}</span>
+                [<span class="log-level-{{.TriggeringEntry.Level}}">{{.TriggeringEntry.Level}}</span>]
+                {{.TriggeringEntry.Message}}
+            </div>
+            {{if .TriggeringEntry.FilePath}}
+            <div style="margin-top: 8px; color: #888; font-size: 11px;">
+                Source: {{.TriggeringEntry.FilePath}}
+            </div>
+            {{end}}
+        </div>
+        {{end}}
+
+        {{if .Labels}}
+        <div class="labels">
+            {{range $key, $value := .Labels}}
+            <span class="label">{{$key}}: {{$value}}</span>
+            {{end}}
+        </div>
+        {{end}}
+    </div>
+    <div class="footer">
+        Sent by BlazeLog
+    </div>
+</body>
+</html>

--- a/internal/notifier/templates/alert.txt
+++ b/internal/notifier/templates/alert.txt
@@ -1,0 +1,33 @@
+BlazeLog Alert: {{.RuleName}}
+================================================================================
+
+Severity: {{.Severity | upper}}
+Time: {{.Timestamp}}
+
+MESSAGE
+-------
+{{.Message}}
+{{if .Description}}
+DESCRIPTION
+-----------
+{{.Description}}
+{{end}}
+{{if gt .Count 0}}
+THRESHOLD ALERT
+---------------
+Count: {{.Count}} events in {{.Window}}
+Threshold: {{.Threshold}}
+{{end}}
+{{if .TriggeringEntry}}
+TRIGGERING LOG ENTRY
+--------------------
+{{.TriggeringEntry.Timestamp}} [{{.TriggeringEntry.Level}}] {{.TriggeringEntry.Message}}
+{{if .TriggeringEntry.FilePath}}Source: {{.TriggeringEntry.FilePath}}{{end}}
+{{end}}
+{{if .Labels}}
+LABELS
+------
+{{range $key, $value := .Labels}}  {{$key}}: {{$value}}
+{{end}}{{end}}
+--------------------------------------------------------------------------------
+Sent by BlazeLog


### PR DESCRIPTION
## Summary

Implements email notification functionality for BlazeLog alerts (Milestone 9).

- Add `Notifier` interface and `Dispatcher` for alert notification routing
- Implement `EmailNotifier` with SMTP/TLS support (ports 587 STARTTLS, 465 implicit TLS)
- Create HTML and plain text email templates with severity-based styling
- Integrate with `blazelog tail` command via new flags:
  - `--alert-rules` - path to alert rules YAML
  - `--notify-email` - recipient emails (repeatable)
  - `--smtp-host`, `--smtp-port`, `--smtp-from` - SMTP config
  - Password via `BLAZELOG_SMTP_PASS` env var
- Add comprehensive tests with mock SMTP server

## Usage Example

```bash
blazelog tail /var/log/nginx/*.log \
    --alert-rules ./alerts.yaml \
    --notify-email admin@example.com \
    --smtp-host smtp.gmail.com \
    --smtp-port 587 \
    --smtp-from "BlazeLog <alerts@example.com>"
```

## Test plan

- [x] Unit tests for email config validation
- [x] Unit tests for template rendering (HTML + plain text)
- [x] Unit tests for alert-to-template data conversion
- [x] Unit tests for dispatcher registration/dispatch
- [x] Unit tests for MIME message building
- [x] Integration test with mock SMTP server

Closes #9