### PR TITLE
Implement Milestone 11: Teams Notifications

### DIFF
--- a/configs/alerts.yaml
+++ b/configs/alerts.yaml
@@ -84,6 +84,7 @@ rules:
     severity: "high"
     notify:
       - "slack"
+      - "teams"
 
   # Magento-specific pattern rule
   - name: "Magento Exception"

--- a/internal/notifier/ratelimit.go
+++ b/internal/notifier/ratelimit.go
@@ -1,0 +1,131 @@
+package notifier
+
+import (
+	"sync"
+	"time"
+)
+
+// RateLimiter implements a sliding window rate limiter for notifications.
+type RateLimiter struct {
+	mu            sync.Mutex
+	maxPerWindow  int
+	window        time.Duration
+	timestamps    []time.Time
+	dropped       int64
+	enabled       bool
+}
+
+// RateLimitConfig holds rate limiter configuration.
+type RateLimitConfig struct {
+	MaxPerWindow int           // Maximum notifications per window (default: 10)
+	Window       time.Duration // Time window (default: 1 minute)
+	Enabled      bool          // Whether rate limiting is enabled (default: true)
+}
+
+// DefaultRateLimitConfig returns default rate limit settings.
+func DefaultRateLimitConfig() RateLimitConfig {
+	return RateLimitConfig{
+		MaxPerWindow: 10,
+		Window:       time.Minute,
+		Enabled:      true,
+	}
+}
+
+// NewRateLimiter creates a new rate limiter with the given configuration.
+func NewRateLimiter(config RateLimitConfig) *RateLimiter {
+	if config.MaxPerWindow <= 0 {
+		config.MaxPerWindow = 10
+	}
+	if config.Window <= 0 {
+		config.Window = time.Minute
+	}
+
+	return &RateLimiter{
+		maxPerWindow: config.MaxPerWindow,
+		window:       config.Window,
+		timestamps:   make([]time.Time, 0, config.MaxPerWindow),
+		enabled:      config.Enabled,
+	}
+}
+
+// Allow checks if a notification is allowed under the rate limit.
+// Returns true if allowed, false if rate limit exceeded.
+func (r *RateLimiter) Allow() bool {
+	if !r.enabled {
+		return true
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-r.window)
+
+	// Remove timestamps outside the window
+	r.cleanup(cutoff)
+
+	// Check if under limit
+	if len(r.timestamps) >= r.maxPerWindow {
+		r.dropped++
+		return false
+	}
+
+	// Add current timestamp
+	r.timestamps = append(r.timestamps, now)
+	return true
+}
+
+// cleanup removes timestamps older than the cutoff time.
+// Must be called with mutex held.
+func (r *RateLimiter) cleanup(cutoff time.Time) {
+	// Find first timestamp within window
+	idx := 0
+	for idx < len(r.timestamps) && r.timestamps[idx].Before(cutoff) {
+		idx++
+	}
+
+	if idx > 0 {
+		// Shift timestamps
+		copy(r.timestamps, r.timestamps[idx:])
+		r.timestamps = r.timestamps[:len(r.timestamps)-idx]
+	}
+}
+
+// Dropped returns the number of notifications dropped due to rate limiting.
+func (r *RateLimiter) Dropped() int64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.dropped
+}
+
+// Stats returns rate limiter statistics.
+func (r *RateLimiter) Stats() RateLimitStats {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return RateLimitStats{
+		Dropped:      r.dropped,
+		CurrentCount: len(r.timestamps),
+		MaxPerWindow: r.maxPerWindow,
+		Window:       r.window,
+		Enabled:      r.enabled,
+	}
+}
+
+// RateLimitStats contains rate limiter statistics.
+type RateLimitStats struct {
+	Dropped      int64         // Total notifications dropped
+	CurrentCount int           // Current count in window
+	MaxPerWindow int           // Maximum allowed per window
+	Window       time.Duration // Window duration
+	Enabled      bool          // Whether rate limiting is enabled
+}
+
+// Reset clears the rate limiter state.
+func (r *RateLimiter) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.timestamps = r.timestamps[:0]
+	r.dropped = 0
+}

--- a/internal/notifier/ratelimit_test.go
+++ b/internal/notifier/ratelimit_test.go
@@ -1,0 +1,259 @@
+package notifier
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateLimiterBasic(t *testing.T) {
+	config := RateLimitConfig{
+		MaxPerWindow: 3,
+		Window:       time.Second,
+		Enabled:      true,
+	}
+	rl := NewRateLimiter(config)
+
+	// First 3 should be allowed
+	for i := 0; i < 3; i++ {
+		if !rl.Allow() {
+			t.Errorf("request %d should be allowed", i+1)
+		}
+	}
+
+	// 4th should be denied
+	if rl.Allow() {
+		t.Error("4th request should be denied")
+	}
+
+	// Check dropped count
+	if dropped := rl.Dropped(); dropped != 1 {
+		t.Errorf("dropped = %d, want 1", dropped)
+	}
+}
+
+func TestRateLimiterWindowExpiry(t *testing.T) {
+	config := RateLimitConfig{
+		MaxPerWindow: 2,
+		Window:       100 * time.Millisecond,
+		Enabled:      true,
+	}
+	rl := NewRateLimiter(config)
+
+	// Use up the limit
+	rl.Allow()
+	rl.Allow()
+
+	// Should be denied
+	if rl.Allow() {
+		t.Error("should be denied before window expires")
+	}
+
+	// Wait for window to expire
+	time.Sleep(150 * time.Millisecond)
+
+	// Should be allowed again
+	if !rl.Allow() {
+		t.Error("should be allowed after window expires")
+	}
+}
+
+func TestRateLimiterDisabled(t *testing.T) {
+	config := RateLimitConfig{
+		MaxPerWindow: 1,
+		Window:       time.Second,
+		Enabled:      false, // Disabled
+	}
+	rl := NewRateLimiter(config)
+
+	// Should always allow when disabled
+	for i := 0; i < 100; i++ {
+		if !rl.Allow() {
+			t.Errorf("request %d should be allowed when disabled", i+1)
+		}
+	}
+
+	// No drops when disabled
+	if dropped := rl.Dropped(); dropped != 0 {
+		t.Errorf("dropped = %d, want 0 when disabled", dropped)
+	}
+}
+
+func TestRateLimiterStats(t *testing.T) {
+	config := RateLimitConfig{
+		MaxPerWindow: 5,
+		Window:       time.Minute,
+		Enabled:      true,
+	}
+	rl := NewRateLimiter(config)
+
+	// Make some requests
+	rl.Allow()
+	rl.Allow()
+	rl.Allow()
+
+	stats := rl.Stats()
+
+	if stats.CurrentCount != 3 {
+		t.Errorf("current count = %d, want 3", stats.CurrentCount)
+	}
+	if stats.MaxPerWindow != 5 {
+		t.Errorf("max per window = %d, want 5", stats.MaxPerWindow)
+	}
+	if stats.Window != time.Minute {
+		t.Errorf("window = %v, want 1m", stats.Window)
+	}
+	if !stats.Enabled {
+		t.Error("should be enabled")
+	}
+	if stats.Dropped != 0 {
+		t.Errorf("dropped = %d, want 0", stats.Dropped)
+	}
+}
+
+func TestRateLimiterReset(t *testing.T) {
+	config := RateLimitConfig{
+		MaxPerWindow: 2,
+		Window:       time.Minute,
+		Enabled:      true,
+	}
+	rl := NewRateLimiter(config)
+
+	// Use up limit and get a drop
+	rl.Allow()
+	rl.Allow()
+	rl.Allow() // This gets dropped
+
+	if dropped := rl.Dropped(); dropped != 1 {
+		t.Errorf("dropped = %d, want 1", dropped)
+	}
+
+	// Reset
+	rl.Reset()
+
+	// Stats should be cleared
+	stats := rl.Stats()
+	if stats.CurrentCount != 0 {
+		t.Errorf("current count after reset = %d, want 0", stats.CurrentCount)
+	}
+	if stats.Dropped != 0 {
+		t.Errorf("dropped after reset = %d, want 0", stats.Dropped)
+	}
+
+	// Should allow again
+	if !rl.Allow() {
+		t.Error("should allow after reset")
+	}
+}
+
+func TestDefaultRateLimitConfig(t *testing.T) {
+	config := DefaultRateLimitConfig()
+
+	if config.MaxPerWindow != 10 {
+		t.Errorf("default max = %d, want 10", config.MaxPerWindow)
+	}
+	if config.Window != time.Minute {
+		t.Errorf("default window = %v, want 1m", config.Window)
+	}
+	if !config.Enabled {
+		t.Error("should be enabled by default")
+	}
+}
+
+func TestNewRateLimiterDefaults(t *testing.T) {
+	// Test with zero/invalid values
+	config := RateLimitConfig{
+		MaxPerWindow: 0,
+		Window:       0,
+		Enabled:      true,
+	}
+	rl := NewRateLimiter(config)
+
+	stats := rl.Stats()
+	if stats.MaxPerWindow != 10 {
+		t.Errorf("should default to 10, got %d", stats.MaxPerWindow)
+	}
+	if stats.Window != time.Minute {
+		t.Errorf("should default to 1m, got %v", stats.Window)
+	}
+}
+
+func TestRateLimiterSlidingWindow(t *testing.T) {
+	config := RateLimitConfig{
+		MaxPerWindow: 3,
+		Window:       200 * time.Millisecond,
+		Enabled:      true,
+	}
+	rl := NewRateLimiter(config)
+
+	// T=0: Make 2 requests
+	rl.Allow()
+	rl.Allow()
+
+	// T=100ms: Wait half the window
+	time.Sleep(100 * time.Millisecond)
+
+	// T=100ms: Make 1 more request (total 3 in window)
+	if !rl.Allow() {
+		t.Error("3rd request should be allowed")
+	}
+
+	// T=100ms: 4th should be denied
+	if rl.Allow() {
+		t.Error("4th request should be denied")
+	}
+
+	// T=200ms: Wait for first 2 requests to expire
+	time.Sleep(100 * time.Millisecond)
+
+	// T=200ms: Should be able to make 2 more requests
+	if !rl.Allow() {
+		t.Error("should allow after partial expiry")
+	}
+	if !rl.Allow() {
+		t.Error("should allow 2nd after partial expiry")
+	}
+}
+
+func TestRateLimiterConcurrentAccess(t *testing.T) {
+	config := RateLimitConfig{
+		MaxPerWindow: 100,
+		Window:       time.Second,
+		Enabled:      true,
+	}
+	rl := NewRateLimiter(config)
+
+	// Run concurrent goroutines
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 20; j++ {
+				rl.Allow()
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all to complete
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Should have 100 allowed, 100 dropped
+	stats := rl.Stats()
+	total := int64(stats.CurrentCount) + stats.Dropped
+
+	// 200 total requests
+	if total != 200 {
+		t.Errorf("total processed = %d, want 200", total)
+	}
+
+	// Exactly 100 should be in window (allowed)
+	if stats.CurrentCount != 100 {
+		t.Errorf("current count = %d, want 100", stats.CurrentCount)
+	}
+
+	// Rest should be dropped
+	if stats.Dropped != 100 {
+		t.Errorf("dropped = %d, want 100", stats.Dropped)
+	}
+}

--- a/internal/notifier/teams.go
+++ b/internal/notifier/teams.go
@@ -1,0 +1,265 @@
+package notifier
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/alerting"
+)
+
+// TeamsConfig holds Microsoft Teams webhook configuration.
+type TeamsConfig struct {
+	WebhookURL string // Teams incoming webhook URL
+}
+
+// Validate validates the Teams configuration.
+func (c *TeamsConfig) Validate() error {
+	if c.WebhookURL == "" {
+		return fmt.Errorf("webhook URL is required")
+	}
+	if !strings.HasPrefix(c.WebhookURL, "https://") {
+		return fmt.Errorf("webhook URL must use HTTPS")
+	}
+	return nil
+}
+
+// TeamsNotifier sends alerts to Microsoft Teams via webhook.
+type TeamsNotifier struct {
+	config     TeamsConfig
+	httpClient *http.Client
+}
+
+// NewTeamsNotifier creates a new Teams notifier.
+func NewTeamsNotifier(config TeamsConfig) (*TeamsNotifier, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid teams config: %w", err)
+	}
+
+	return &TeamsNotifier{
+		config: config,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}, nil
+}
+
+// Name returns "teams".
+func (t *TeamsNotifier) Name() string {
+	return "teams"
+}
+
+// Send sends an alert to Microsoft Teams.
+func (t *TeamsNotifier) Send(ctx context.Context, alert *alerting.Alert) error {
+	payload := t.buildPayload(alert)
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.config.WebhookURL, bytes.NewReader(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("teams API error: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// Close is a no-op for Teams notifier.
+func (t *TeamsNotifier) Close() error {
+	return nil
+}
+
+// teamsMessage represents the Teams webhook payload with Adaptive Card.
+type teamsMessage struct {
+	Type        string            `json:"type"`
+	Attachments []teamsAttachment `json:"attachments"`
+}
+
+// teamsAttachment represents an attachment in the Teams message.
+type teamsAttachment struct {
+	ContentType string       `json:"contentType"`
+	ContentURL  *string      `json:"contentUrl"`
+	Content     adaptiveCard `json:"content"`
+}
+
+// adaptiveCard represents a Microsoft Adaptive Card.
+type adaptiveCard struct {
+	Schema  string        `json:"$schema"`
+	Type    string        `json:"type"`
+	Version string        `json:"version"`
+	Body    []interface{} `json:"body"`
+}
+
+// Adaptive Card element types
+type textBlock struct {
+	Type   string `json:"type"`
+	Text   string `json:"text"`
+	Size   string `json:"size,omitempty"`
+	Weight string `json:"weight,omitempty"`
+	Color  string `json:"color,omitempty"`
+	Wrap   bool   `json:"wrap,omitempty"`
+}
+
+type factSet struct {
+	Type  string `json:"type"`
+	Facts []fact `json:"facts"`
+}
+
+type fact struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+}
+
+type container struct {
+	Type  string        `json:"type"`
+	Style string        `json:"style,omitempty"`
+	Items []interface{} `json:"items"`
+}
+
+// buildPayload builds the Teams Adaptive Card message payload.
+func (t *TeamsNotifier) buildPayload(alert *alerting.Alert) teamsMessage {
+	timestamp := alert.Timestamp.Format("2006-01-02 15:04:05 MST")
+	emoji := severityEmoji(alert.Severity)
+	color := severityColor(alert.Severity)
+
+	body := []interface{}{}
+
+	// Header container with severity color
+	headerContainer := container{
+		Type:  "Container",
+		Style: color,
+		Items: []interface{}{
+			textBlock{
+				Type:   "TextBlock",
+				Text:   fmt.Sprintf("%s BlazeLog Alert: %s", emoji, alert.RuleName),
+				Size:   "Large",
+				Weight: "Bolder",
+				Wrap:   true,
+			},
+		},
+	}
+	body = append(body, headerContainer)
+
+	// Alert details fact set
+	facts := []fact{
+		{Title: "Severity", Value: fmt.Sprintf("%s %s", emoji, strings.ToUpper(string(alert.Severity)))},
+		{Title: "Time", Value: timestamp},
+	}
+
+	body = append(body, factSet{
+		Type:  "FactSet",
+		Facts: facts,
+	})
+
+	// Message
+	body = append(body, textBlock{
+		Type:   "TextBlock",
+		Text:   fmt.Sprintf("**Message:** %s", alert.Message),
+		Wrap:   true,
+	})
+
+	// Threshold info if applicable
+	if alert.Threshold > 0 {
+		body = append(body, factSet{
+			Type: "FactSet",
+			Facts: []fact{
+				{Title: "Count", Value: fmt.Sprintf("%d", alert.Count)},
+				{Title: "Threshold", Value: fmt.Sprintf("%d in %s", alert.Threshold, alert.Window)},
+			},
+		})
+	}
+
+	// Triggering entry if available
+	if alert.TriggeringEntry != nil {
+		entry := alert.TriggeringEntry
+		entryText := fmt.Sprintf("`%s [%s] %s`",
+			entry.Timestamp.Format("15:04:05"),
+			strings.ToUpper(string(entry.Level)),
+			truncate(entry.Message, 200))
+
+		if entry.FilePath != "" {
+			entryText = fmt.Sprintf("**File:** `%s`\n\n%s", entry.FilePath, entryText)
+		}
+
+		body = append(body, textBlock{
+			Type: "TextBlock",
+			Text: entryText,
+			Wrap: true,
+		})
+	}
+
+	// Description
+	if alert.Description != "" {
+		body = append(body, textBlock{
+			Type:  "TextBlock",
+			Text:  fmt.Sprintf("_Rule: %s_", alert.Description),
+			Wrap:  true,
+			Color: "Light",
+		})
+	}
+
+	// Labels if present
+	if len(alert.Labels) > 0 {
+		var labelParts []string
+		for k, v := range alert.Labels {
+			labelParts = append(labelParts, fmt.Sprintf("`%s=%s`", k, v))
+		}
+		body = append(body, textBlock{
+			Type:  "TextBlock",
+			Text:  fmt.Sprintf("**Labels:** %s", strings.Join(labelParts, " ")),
+			Wrap:  true,
+			Color: "Light",
+		})
+	}
+
+	return teamsMessage{
+		Type: "message",
+		Attachments: []teamsAttachment{
+			{
+				ContentType: "application/vnd.microsoft.card.adaptive",
+				ContentURL:  nil,
+				Content: adaptiveCard{
+					Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
+					Type:    "AdaptiveCard",
+					Version: "1.4",
+					Body:    body,
+				},
+			},
+		},
+	}
+}
+
+// severityColor returns an Adaptive Card container style for the severity level.
+func severityColor(severity alerting.Severity) string {
+	switch severity {
+	case alerting.SeverityCritical:
+		return "attention" // red
+	case alerting.SeverityHigh:
+		return "warning" // orange/yellow
+	case alerting.SeverityMedium:
+		return "accent" // blue
+	case alerting.SeverityLow:
+		return "good" // green
+	default:
+		return "default"
+	}
+}

--- a/internal/notifier/teams_test.go
+++ b/internal/notifier/teams_test.go
@@ -1,0 +1,376 @@
+package notifier
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/alerting"
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+func TestTeamsConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  TeamsConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "empty config",
+			config:  TeamsConfig{},
+			wantErr: true,
+			errMsg:  "webhook URL is required",
+		},
+		{
+			name: "http URL rejected",
+			config: TeamsConfig{
+				WebhookURL: "http://outlook.office.com/webhook/xxx",
+			},
+			wantErr: true,
+			errMsg:  "webhook URL must use HTTPS",
+		},
+		{
+			name: "valid config",
+			config: TeamsConfig{
+				WebhookURL: "https://outlook.office.com/webhook/xxx",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errMsg)
+				} else if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tt.errMsg, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestTeamsNotifierName(t *testing.T) {
+	notifier := &TeamsNotifier{}
+	if got := notifier.Name(); got != "teams" {
+		t.Errorf("Name() = %q, want %q", got, "teams")
+	}
+}
+
+func TestTeamsNotifierClose(t *testing.T) {
+	notifier := &TeamsNotifier{}
+	if err := notifier.Close(); err != nil {
+		t.Errorf("Close() returned error: %v", err)
+	}
+}
+
+func TestTeamsNotifierSend(t *testing.T) {
+	var receivedPayload teamsMessage
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST method, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", ct)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &receivedPayload); err != nil {
+			t.Errorf("failed to unmarshal payload: %v", err)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("1"))
+	}))
+	defer server.Close()
+
+	// Use test server URL (allow non-HTTPS for testing)
+	notifier := &TeamsNotifier{
+		config: TeamsConfig{
+			WebhookURL: server.URL,
+		},
+		httpClient: server.Client(),
+	}
+
+	alert := &alerting.Alert{
+		RuleName:    "Test Alert",
+		Description: "Test description",
+		Severity:    alerting.SeverityCritical,
+		Message:     "Test message",
+		Timestamp:   time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+		Count:       5,
+		Threshold:   3,
+		Window:      "5m",
+	}
+
+	ctx := context.Background()
+	if err := notifier.Send(ctx, alert); err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	// Verify payload structure
+	if receivedPayload.Type != "message" {
+		t.Errorf("payload type = %q, want %q", receivedPayload.Type, "message")
+	}
+
+	if len(receivedPayload.Attachments) == 0 {
+		t.Fatal("expected attachments in payload")
+	}
+
+	attachment := receivedPayload.Attachments[0]
+	if attachment.ContentType != "application/vnd.microsoft.card.adaptive" {
+		t.Errorf("attachment contentType = %q, want adaptive card", attachment.ContentType)
+	}
+
+	if attachment.Content.Version != "1.4" {
+		t.Errorf("card version = %q, want %q", attachment.Content.Version, "1.4")
+	}
+
+	if len(attachment.Content.Body) == 0 {
+		t.Fatal("expected body elements in card")
+	}
+}
+
+func TestTeamsNotifierSendWithTriggeringEntry(t *testing.T) {
+	var receivedPayload teamsMessage
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedPayload)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := &TeamsNotifier{
+		config:     TeamsConfig{WebhookURL: server.URL},
+		httpClient: server.Client(),
+	}
+
+	alert := &alerting.Alert{
+		RuleName:    "Pattern Alert",
+		Description: "Detected pattern match",
+		Severity:    alerting.SeverityHigh,
+		Message:     "FATAL error detected",
+		Timestamp:   time.Now(),
+		TriggeringEntry: &models.LogEntry{
+			Timestamp: time.Now(),
+			Level:     models.LevelError,
+			Message:   "Database connection failed",
+			FilePath:  "/var/log/app/error.log",
+		},
+		Labels: map[string]string{
+			"environment": "production",
+			"project":     "ecommerce",
+		},
+	}
+
+	ctx := context.Background()
+	if err := notifier.Send(ctx, alert); err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	// Verify adaptive card structure
+	if len(receivedPayload.Attachments) == 0 {
+		t.Fatal("expected attachments")
+	}
+
+	// Check body contains expected elements
+	bodyJSON, _ := json.Marshal(receivedPayload.Attachments[0].Content.Body)
+	bodyStr := string(bodyJSON)
+
+	if !strings.Contains(bodyStr, "Database connection failed") {
+		t.Error("triggering entry message not found in payload")
+	}
+
+	if !strings.Contains(bodyStr, "environment=production") {
+		t.Error("labels not found in payload")
+	}
+
+	if !strings.Contains(bodyStr, "/var/log/app/error.log") {
+		t.Error("file path not found in payload")
+	}
+}
+
+func TestTeamsNotifierHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	notifier := &TeamsNotifier{
+		config:     TeamsConfig{WebhookURL: server.URL},
+		httpClient: server.Client(),
+	}
+
+	alert := &alerting.Alert{
+		RuleName:  "Test",
+		Severity:  alerting.SeverityLow,
+		Timestamp: time.Now(),
+	}
+
+	err := notifier.Send(context.Background(), alert)
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+	if !strings.Contains(err.Error(), "status 500") {
+		t.Errorf("error should contain status code, got %q", err.Error())
+	}
+}
+
+func TestTeamsNotifierContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second) // Slow response
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := &TeamsNotifier{
+		config:     TeamsConfig{WebhookURL: server.URL},
+		httpClient: server.Client(),
+	}
+
+	alert := &alerting.Alert{
+		RuleName:  "Test",
+		Severity:  alerting.SeverityLow,
+		Timestamp: time.Now(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := notifier.Send(ctx, alert)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestSeverityColor(t *testing.T) {
+	tests := []struct {
+		severity alerting.Severity
+		want     string
+	}{
+		{alerting.SeverityCritical, "attention"},
+		{alerting.SeverityHigh, "warning"},
+		{alerting.SeverityMedium, "accent"},
+		{alerting.SeverityLow, "good"},
+		{alerting.Severity("unknown"), "default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.severity), func(t *testing.T) {
+			got := severityColor(tt.severity)
+			if got != tt.want {
+				t.Errorf("severityColor(%q) = %q, want %q", tt.severity, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTeamsAdaptiveCardFormatting(t *testing.T) {
+	notifier := &TeamsNotifier{}
+
+	alert := &alerting.Alert{
+		RuleName:    "High Error Rate",
+		Description: "More than 100 errors in 5 minutes",
+		Severity:    alerting.SeverityCritical,
+		Message:     "Threshold exceeded: 150 events in 5m (threshold: 100)",
+		Timestamp:   time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+		Count:       150,
+		Threshold:   100,
+		Window:      "5m",
+	}
+
+	payload := notifier.buildPayload(alert)
+
+	// Verify message structure
+	if payload.Type != "message" {
+		t.Errorf("payload type = %q, want %q", payload.Type, "message")
+	}
+
+	if len(payload.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(payload.Attachments))
+	}
+
+	attachment := payload.Attachments[0]
+	if attachment.ContentType != "application/vnd.microsoft.card.adaptive" {
+		t.Errorf("wrong content type: %s", attachment.ContentType)
+	}
+
+	card := attachment.Content
+	if card.Type != "AdaptiveCard" {
+		t.Errorf("card type = %q, want %q", card.Type, "AdaptiveCard")
+	}
+
+	if card.Version != "1.4" {
+		t.Errorf("card version = %q, want %q", card.Version, "1.4")
+	}
+
+	// Verify JSON serialization works
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	jsonStr := string(jsonData)
+	if !strings.Contains(jsonStr, "High Error Rate") {
+		t.Error("JSON missing rule name")
+	}
+	if !strings.Contains(jsonStr, "CRITICAL") {
+		t.Error("JSON missing severity")
+	}
+	if !strings.Contains(jsonStr, "attention") {
+		t.Error("JSON missing critical color style")
+	}
+}
+
+func TestNewTeamsNotifierValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  TeamsConfig
+		wantErr bool
+	}{
+		{
+			name:    "empty URL",
+			config:  TeamsConfig{},
+			wantErr: true,
+		},
+		{
+			name: "http URL",
+			config: TeamsConfig{
+				WebhookURL: "http://example.com/webhook",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid URL",
+			config: TeamsConfig{
+				WebhookURL: "https://outlook.office.com/webhook/xxx",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewTeamsNotifier(tt.config)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements Microsoft Teams webhook notifications with Adaptive Card formatting and adds global notification rate limiting across all channels.

- Add `TeamsNotifier` with Adaptive Card v1.4 format
- Add `--notify-teams` CLI flag for tail command  
- Implement `RateLimiter` for cross-channel notification throttling (10/min default)
- Integrate rate limiting into `Dispatcher`
- Add comprehensive test coverage

## Changes

| File | Description |
|------|-------------|
| `internal/notifier/teams.go` | Teams notifier with Adaptive Card formatting |
| `internal/notifier/teams_test.go` | Teams notifier tests |
| `internal/notifier/ratelimit.go` | Sliding window rate limiter |
| `internal/notifier/ratelimit_test.go` | Rate limiter tests |
| `internal/notifier/notifier.go` | Integrate rate limiting into Dispatcher |
| `cmd/blazectl/cmd/tail.go` | Add `--notify-teams` flag |
| `configs/alerts.yaml` | Add teams to example rules |

## Usage

```bash
blazelog tail /var/log/*.log \
  --alert-rules ./alerts.yaml \
  --notify-teams https://outlook.office.com/webhook/xxx
```

## Test plan

- [ ] Teams notifications send correctly formatted Adaptive Cards
- [ ] Rate limiting prevents notification spam
- [ ] All new unit tests pass

Closes #11