### PR TITLE
14 - Implement server log receiver with gRPC handler

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -1,0 +1,67 @@
+// Package main provides the BlazeLog server CLI.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config represents the server configuration.
+type Config struct {
+	Server  ServerConfig `yaml:"server"`
+	Verbose bool         `yaml:"-"` // set via CLI flag
+}
+
+// ServerConfig contains server settings.
+type ServerConfig struct {
+	GRPCAddress string `yaml:"grpc_address"` // gRPC listen address (default: :9443)
+	HTTPAddress string `yaml:"http_address"` // HTTP listen address (default: :8080)
+}
+
+// LoadConfig loads configuration from a YAML file.
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config file: %w", err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	cfg.setDefaults()
+
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("validate config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// DefaultConfig returns a configuration with default values.
+func DefaultConfig() *Config {
+	cfg := &Config{}
+	cfg.setDefaults()
+	return cfg
+}
+
+// setDefaults sets default values for missing config fields.
+func (c *Config) setDefaults() {
+	if c.Server.GRPCAddress == "" {
+		c.Server.GRPCAddress = ":9443"
+	}
+	if c.Server.HTTPAddress == "" {
+		c.Server.HTTPAddress = ":8080"
+	}
+}
+
+// Validate checks the configuration for errors.
+func (c *Config) Validate() error {
+	if c.Server.GRPCAddress == "" {
+		return fmt.Errorf("server.grpc_address is required")
+	}
+	return nil
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/good-yellow-bee/blazelog/internal/server"
+	"github.com/good-yellow-bee/blazelog/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	configFile string
+	grpcAddr   string
+	verbose    bool
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "blazelog-server",
+	Short: "BlazeLog Server - Central log processing server",
+	Long: `BlazeLog Server receives logs from agents, processes them,
+and provides a central point for log management and analysis.`,
+	RunE: runServer,
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("blazelog-server %s\n", config.Version)
+		fmt.Printf("  commit: %s\n", config.Commit)
+		fmt.Printf("  built:  %s\n", config.BuildTime)
+	},
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "config file path (optional)")
+	rootCmd.PersistentFlags().StringVarP(&grpcAddr, "address", "a", ":9443", "gRPC listen address")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+
+	rootCmd.AddCommand(versionCmd)
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func runServer(cmd *cobra.Command, args []string) error {
+	var cfg *Config
+
+	// Load configuration from file if provided
+	if configFile != "" {
+		var err error
+		cfg, err = LoadConfig(configFile)
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+	} else {
+		cfg = DefaultConfig()
+	}
+
+	// Override with CLI flags
+	if grpcAddr != "" {
+		cfg.Server.GRPCAddress = grpcAddr
+	}
+	cfg.Verbose = verbose
+
+	// Build server config
+	serverCfg := &server.Config{
+		GRPCAddress: cfg.Server.GRPCAddress,
+		Verbose:     cfg.Verbose,
+	}
+
+	// Create server
+	srv := server.New(serverCfg)
+
+	// Setup signal handling
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		sig := <-sigChan
+		log.Printf("received signal %v, shutting down...", sig)
+		cancel()
+	}()
+
+	// Run server
+	log.Printf("starting blazelog-server %s", config.Version)
+	log.Printf("gRPC listening on %s", cfg.Server.GRPCAddress)
+
+	if err := srv.Run(ctx); err != nil {
+		return fmt.Errorf("run server: %w", err)
+	}
+
+	log.Printf("server stopped")
+	return nil
+}

--- a/configs/server.yaml
+++ b/configs/server.yaml
@@ -1,0 +1,11 @@
+# BlazeLog Server Configuration
+#
+# This is an example configuration file for the BlazeLog server.
+# Copy and modify as needed.
+
+server:
+  # gRPC listen address for agent connections
+  grpc_address: ":9443"
+
+  # HTTP listen address for REST API (future)
+  http_address: ":8080"

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"context"
+	"io"
+	"log"
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/uuid"
+	blazelogv1 "github.com/good-yellow-bee/blazelog/internal/proto/blazelog/v1"
+	"google.golang.org/grpc"
+)
+
+// Handler implements the LogServiceServer gRPC interface.
+type Handler struct {
+	blazelogv1.UnimplementedLogServiceServer
+
+	processor *Processor
+	agents    sync.Map // agent_id -> *blazelogv1.AgentInfo
+	verbose   bool
+
+	// Metrics
+	totalBatches  uint64
+	totalEntries  uint64
+	activeStreams int32
+}
+
+// NewHandler creates a new gRPC handler.
+func NewHandler(processor *Processor, verbose bool) *Handler {
+	return &Handler{
+		processor: processor,
+		verbose:   verbose,
+	}
+}
+
+// Register handles agent registration.
+func (h *Handler) Register(ctx context.Context, req *blazelogv1.RegisterRequest) (*blazelogv1.RegisterResponse, error) {
+	agent := req.Agent
+	if agent == nil {
+		return &blazelogv1.RegisterResponse{
+			Success:      false,
+			ErrorMessage: "agent info is required",
+		}, nil
+	}
+
+	// Generate agent ID if not provided
+	agentID := agent.AgentId
+	if agentID == "" {
+		agentID = uuid.New().String()
+	}
+
+	// Store agent info
+	h.agents.Store(agentID, agent)
+
+	log.Printf("agent registered: id=%s name=%s hostname=%s sources=%d",
+		agentID, agent.Name, agent.Hostname, len(agent.Sources))
+
+	return &blazelogv1.RegisterResponse{
+		Success: true,
+		AgentId: agentID,
+		Config: &blazelogv1.StreamConfig{
+			MaxBatchSize:       100,
+			FlushIntervalMs:    1000,
+			CompressionEnabled: false,
+		},
+	}, nil
+}
+
+// StreamLogs handles bidirectional log streaming from agents.
+func (h *Handler) StreamLogs(stream grpc.BidiStreamingServer[blazelogv1.LogBatch, blazelogv1.StreamResponse]) error {
+	atomic.AddInt32(&h.activeStreams, 1)
+	defer atomic.AddInt32(&h.activeStreams, -1)
+
+	if h.verbose {
+		log.Printf("stream started, active streams: %d", atomic.LoadInt32(&h.activeStreams))
+	}
+
+	for {
+		batch, err := stream.Recv()
+		if err == io.EOF {
+			if h.verbose {
+				log.Printf("stream closed by client")
+			}
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		// Process the batch
+		if err := h.processor.ProcessBatch(batch); err != nil {
+			log.Printf("process batch error: %v", err)
+			// Send error response but continue
+			if sendErr := stream.Send(&blazelogv1.StreamResponse{
+				AckedSequence: batch.Sequence,
+				Error:         err.Error(),
+			}); sendErr != nil {
+				return sendErr
+			}
+			continue
+		}
+
+		// Update metrics
+		atomic.AddUint64(&h.totalBatches, 1)
+		atomic.AddUint64(&h.totalEntries, uint64(len(batch.Entries)))
+
+		// Send acknowledgement
+		if err := stream.Send(&blazelogv1.StreamResponse{
+			AckedSequence: batch.Sequence,
+		}); err != nil {
+			return err
+		}
+	}
+}
+
+// Heartbeat handles agent heartbeat messages.
+func (h *Handler) Heartbeat(ctx context.Context, req *blazelogv1.HeartbeatRequest) (*blazelogv1.HeartbeatResponse, error) {
+	if h.verbose {
+		status := req.Status
+		if status != nil {
+			log.Printf("heartbeat from %s: processed=%d buffer=%d sources=%d",
+				req.AgentId, status.EntriesProcessed, status.BufferSize, status.ActiveSources)
+		} else {
+			log.Printf("heartbeat from %s", req.AgentId)
+		}
+	}
+
+	return &blazelogv1.HeartbeatResponse{
+		Acknowledged: true,
+	}, nil
+}
+
+// Stats returns current handler statistics.
+func (h *Handler) Stats() (batches, entries uint64, streams int32) {
+	return atomic.LoadUint64(&h.totalBatches),
+		atomic.LoadUint64(&h.totalEntries),
+		atomic.LoadInt32(&h.activeStreams)
+}
+
+// AgentCount returns the number of registered agents.
+func (h *Handler) AgentCount() int {
+	count := 0
+	h.agents.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	return count
+}

--- a/internal/server/processor.go
+++ b/internal/server/processor.go
@@ -1,0 +1,99 @@
+// Package server provides the BlazeLog server implementation.
+package server
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	blazelogv1 "github.com/good-yellow-bee/blazelog/internal/proto/blazelog/v1"
+)
+
+// ANSI color codes for log levels.
+const (
+	colorReset  = "\033[0m"
+	colorRed    = "\033[31m"
+	colorYellow = "\033[33m"
+	colorBlue   = "\033[34m"
+	colorGray   = "\033[90m"
+)
+
+// Processor handles log processing and output.
+type Processor struct {
+	verbose bool
+}
+
+// NewProcessor creates a new log processor.
+func NewProcessor(verbose bool) *Processor {
+	return &Processor{
+		verbose: verbose,
+	}
+}
+
+// ProcessBatch processes a batch of log entries.
+func (p *Processor) ProcessBatch(batch *blazelogv1.LogBatch) error {
+	for _, entry := range batch.Entries {
+		output := p.formatEntry(entry, batch.AgentId)
+		log.Print(output)
+	}
+	return nil
+}
+
+// formatEntry formats a log entry for console output.
+func (p *Processor) formatEntry(entry *blazelogv1.LogEntry, agentID string) string {
+	// Format timestamp
+	var timestamp string
+	if entry.Timestamp != nil {
+		timestamp = entry.Timestamp.AsTime().Format(time.DateTime)
+	} else {
+		timestamp = time.Now().Format(time.DateTime)
+	}
+
+	// Format level with color
+	level := p.formatLevel(entry.Level)
+
+	// Format source (truncate if too long)
+	source := entry.Source
+	if len(source) > 15 {
+		source = source[:15]
+	}
+
+	// Format agent ID (use short form)
+	agent := agentID
+	if len(agent) > 8 {
+		agent = agent[:8]
+	}
+
+	// Build output string
+	var sb strings.Builder
+	sb.WriteString(timestamp)
+	sb.WriteString(" ")
+	sb.WriteString(level)
+	sb.WriteString(" ")
+	sb.WriteString(fmt.Sprintf("%-8s", agent))
+	sb.WriteString(" ")
+	sb.WriteString(fmt.Sprintf("%-15s", source))
+	sb.WriteString(" ")
+	sb.WriteString(entry.Message)
+
+	return sb.String()
+}
+
+// formatLevel formats the log level with ANSI colors.
+func (p *Processor) formatLevel(level blazelogv1.LogLevel) string {
+	switch level {
+	case blazelogv1.LogLevel_LOG_LEVEL_DEBUG:
+		return colorGray + "[DEBUG]" + colorReset
+	case blazelogv1.LogLevel_LOG_LEVEL_INFO:
+		return colorBlue + "[INFO] " + colorReset
+	case blazelogv1.LogLevel_LOG_LEVEL_WARNING:
+		return colorYellow + "[WARN] " + colorReset
+	case blazelogv1.LogLevel_LOG_LEVEL_ERROR:
+		return colorRed + "[ERROR]" + colorReset
+	case blazelogv1.LogLevel_LOG_LEVEL_FATAL:
+		return colorRed + "[FATAL]" + colorReset
+	default:
+		return "[UNKN] "
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+
+	blazelogv1 "github.com/good-yellow-bee/blazelog/internal/proto/blazelog/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// Config holds server configuration.
+type Config struct {
+	GRPCAddress string
+	Verbose     bool
+}
+
+// Server is the BlazeLog gRPC server.
+type Server struct {
+	config     *Config
+	grpcServer *grpc.Server
+	handler    *Handler
+	processor  *Processor
+}
+
+// New creates a new BlazeLog server.
+func New(cfg *Config) *Server {
+	processor := NewProcessor(cfg.Verbose)
+	handler := NewHandler(processor, cfg.Verbose)
+
+	grpcServer := grpc.NewServer(
+		grpc.Creds(insecure.NewCredentials()),
+	)
+	blazelogv1.RegisterLogServiceServer(grpcServer, handler)
+
+	return &Server{
+		config:     cfg,
+		grpcServer: grpcServer,
+		handler:    handler,
+		processor:  processor,
+	}
+}
+
+// Run starts the server and blocks until context is cancelled.
+func (s *Server) Run(ctx context.Context) error {
+	listener, err := net.Listen("tcp", s.config.GRPCAddress)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", s.config.GRPCAddress, err)
+	}
+
+	log.Printf("gRPC server listening on %s", s.config.GRPCAddress)
+
+	// Handle shutdown
+	go func() {
+		<-ctx.Done()
+		log.Printf("shutting down gRPC server...")
+		s.grpcServer.GracefulStop()
+	}()
+
+	if err := s.grpcServer.Serve(listener); err != nil {
+		return fmt.Errorf("serve: %w", err)
+	}
+
+	return nil
+}
+
+// Shutdown gracefully stops the server.
+func (s *Server) Shutdown() {
+	s.grpcServer.GracefulStop()
+}
+
+// Stats returns current server statistics.
+func (s *Server) Stats() (batches, entries uint64, streams int32, agents int) {
+	batches, entries, streams = s.handler.Stats()
+	agents = s.handler.AgentCount()
+	return
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,242 @@
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	blazelogv1 "github.com/good-yellow-bee/blazelog/internal/proto/blazelog/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestServerIntegration(t *testing.T) {
+	// Find available port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to find available port: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	// Start server
+	cfg := &Config{
+		GRPCAddress: addr,
+		Verbose:     true,
+	}
+	srv := New(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- srv.Run(ctx)
+	}()
+
+	// Wait for server to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Connect client
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	client := blazelogv1.NewLogServiceClient(conn)
+
+	// Test Register
+	t.Run("Register", func(t *testing.T) {
+		resp, err := client.Register(ctx, &blazelogv1.RegisterRequest{
+			Agent: &blazelogv1.AgentInfo{
+				AgentId:  "test-agent-1",
+				Name:     "Test Agent",
+				Hostname: "localhost",
+				Version:  "1.0.0",
+				Os:       "linux",
+				Arch:     "amd64",
+				Sources: []*blazelogv1.LogSource{
+					{Name: "nginx", Path: "/var/log/nginx/access.log"},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("Register failed: %v", err)
+		}
+		if !resp.Success {
+			t.Fatalf("Register not successful: %s", resp.ErrorMessage)
+		}
+		if resp.AgentId != "test-agent-1" {
+			t.Errorf("expected agent ID 'test-agent-1', got '%s'", resp.AgentId)
+		}
+		if resp.Config == nil {
+			t.Error("expected config in response")
+		}
+	})
+
+	// Test StreamLogs
+	t.Run("StreamLogs", func(t *testing.T) {
+		stream, err := client.StreamLogs(ctx)
+		if err != nil {
+			t.Fatalf("StreamLogs failed: %v", err)
+		}
+
+		// Send a batch
+		batch := &blazelogv1.LogBatch{
+			AgentId:  "test-agent-1",
+			Sequence: 1,
+			Entries: []*blazelogv1.LogEntry{
+				{
+					Timestamp: timestamppb.Now(),
+					Level:     blazelogv1.LogLevel_LOG_LEVEL_INFO,
+					Message:   "Test log message",
+					Source:    "test-source",
+					Type:      blazelogv1.LogType_LOG_TYPE_NGINX,
+				},
+				{
+					Timestamp: timestamppb.Now(),
+					Level:     blazelogv1.LogLevel_LOG_LEVEL_ERROR,
+					Message:   "Test error message",
+					Source:    "test-source",
+					Type:      blazelogv1.LogType_LOG_TYPE_NGINX,
+				},
+			},
+		}
+
+		if err := stream.Send(batch); err != nil {
+			t.Fatalf("Send failed: %v", err)
+		}
+
+		// Receive acknowledgement
+		resp, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv failed: %v", err)
+		}
+		if resp.AckedSequence != 1 {
+			t.Errorf("expected acked sequence 1, got %d", resp.AckedSequence)
+		}
+		if resp.Error != "" {
+			t.Errorf("unexpected error: %s", resp.Error)
+		}
+
+		// Close stream
+		if err := stream.CloseSend(); err != nil {
+			t.Fatalf("CloseSend failed: %v", err)
+		}
+	})
+
+	// Test Heartbeat
+	t.Run("Heartbeat", func(t *testing.T) {
+		resp, err := client.Heartbeat(ctx, &blazelogv1.HeartbeatRequest{
+			AgentId:   "test-agent-1",
+			Timestamp: timestamppb.Now(),
+			Status: &blazelogv1.AgentStatus{
+				EntriesProcessed: 100,
+				BufferSize:       10,
+				ActiveSources:    1,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Heartbeat failed: %v", err)
+		}
+		if !resp.Acknowledged {
+			t.Error("expected heartbeat to be acknowledged")
+		}
+	})
+
+	// Verify stats
+	batches, entries, _, agents := srv.Stats()
+	if batches != 1 {
+		t.Errorf("expected 1 batch, got %d", batches)
+	}
+	if entries != 2 {
+		t.Errorf("expected 2 entries, got %d", entries)
+	}
+	if agents != 1 {
+		t.Errorf("expected 1 agent, got %d", agents)
+	}
+
+	// Shutdown
+	cancel()
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Errorf("server error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("server shutdown timeout")
+	}
+}
+
+func TestHandler_RegisterWithoutAgentInfo(t *testing.T) {
+	processor := NewProcessor(false)
+	handler := NewHandler(processor, false)
+
+	resp, err := handler.Register(context.Background(), &blazelogv1.RegisterRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Success {
+		t.Error("expected registration to fail without agent info")
+	}
+	if resp.ErrorMessage == "" {
+		t.Error("expected error message")
+	}
+}
+
+func TestHandler_RegisterGeneratesAgentID(t *testing.T) {
+	processor := NewProcessor(false)
+	handler := NewHandler(processor, false)
+
+	resp, err := handler.Register(context.Background(), &blazelogv1.RegisterRequest{
+		Agent: &blazelogv1.AgentInfo{
+			Name:     "Test Agent",
+			Hostname: "localhost",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected registration to succeed: %s", resp.ErrorMessage)
+	}
+	if resp.AgentId == "" {
+		t.Error("expected generated agent ID")
+	}
+}
+
+func TestProcessor_FormatEntry(t *testing.T) {
+	processor := NewProcessor(false)
+
+	entry := &blazelogv1.LogEntry{
+		Timestamp: timestamppb.Now(),
+		Level:     blazelogv1.LogLevel_LOG_LEVEL_ERROR,
+		Message:   "Test error",
+		Source:    "nginx",
+	}
+
+	output := processor.formatEntry(entry, "agent-123")
+	if output == "" {
+		t.Error("expected non-empty output")
+	}
+	// Should contain the message
+	if !contains(output, "Test error") {
+		t.Errorf("output should contain message: %s", output)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Implements Milestone 14: Server Log Receiver

- Add `blazelog-server` binary with Cobra CLI
- Implement `LogServiceServer` gRPC interface (Register, StreamLogs, Heartbeat)
- Add log processor with colored console output
- Add integration tests for full agent-server flow
- Add example `server.yaml` config

## Changes

| File | Description |
|------|-------------|
| `cmd/server/main.go` | Server entry point with Cobra CLI, signal handling |
| `cmd/server/config.go` | YAML config loading with defaults |
| `internal/server/server.go` | gRPC server orchestrator |
| `internal/server/handler.go` | LogServiceServer implementation |
| `internal/server/processor.go` | Log formatting with colored output |
| `internal/server/server_test.go` | Integration tests |
| `configs/server.yaml` | Example configuration |

## Test plan

- [x] All tests pass (`go test ./...`)
- [x] Server binary builds (`go build ./cmd/server`)
- [x] Integration test verifies Register, StreamLogs, Heartbeat
- [ ] Manual test: run server + agent, verify logs appear

Closes #14