### PR TITLE
15 - Implement mTLS security for agent-server communication

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -85,6 +85,16 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		Verbose:       verbose,
 	}
 
+	// Configure TLS if enabled
+	if cfg.Server.TLS.Enabled {
+		agentCfg.TLS = &agent.TLSConfig{
+			CertFile:           cfg.Server.TLS.CertFile,
+			KeyFile:            cfg.Server.TLS.KeyFile,
+			CAFile:             cfg.Server.TLS.CAFile,
+			InsecureSkipVerify: cfg.Server.TLS.InsecureSkipVerify,
+		}
+	}
+
 	// Create agent
 	a, err := agent.New(agentCfg)
 	if err != nil {

--- a/cmd/blazectl/cmd/ca.go
+++ b/cmd/blazectl/cmd/ca.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/good-yellow-bee/blazelog/internal/security"
+	"github.com/spf13/cobra"
+)
+
+var (
+	caOutputDir string
+	caValidDays int
+)
+
+// caCmd represents the ca command group
+var caCmd = &cobra.Command{
+	Use:   "ca",
+	Short: "Certificate Authority management",
+	Long:  `Commands for managing the BlazeLog Certificate Authority.`,
+}
+
+// caInitCmd represents the ca init command
+var caInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize a new Certificate Authority",
+	Long: `Initialize a new Certificate Authority for BlazeLog mTLS.
+
+Creates a CA certificate and private key that can be used to sign
+server and agent certificates.
+
+Example:
+  blazelog ca init --output-dir ./certs
+  blazelog ca init --output-dir /etc/blazelog/certs --valid-days 3650`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if caOutputDir == "" {
+			return fmt.Errorf("--output-dir is required")
+		}
+
+		PrintVerbose("Generating CA certificate...")
+		PrintVerbose("  Output directory: %s", caOutputDir)
+		PrintVerbose("  Validity: %d days", caValidDays)
+
+		if err := security.GenerateCA(caOutputDir, caValidDays); err != nil {
+			return fmt.Errorf("generate CA: %w", err)
+		}
+
+		fmt.Printf("CA certificate generated successfully:\n")
+		fmt.Printf("  Certificate: %s/ca.crt\n", caOutputDir)
+		fmt.Printf("  Private key: %s/ca.key\n", caOutputDir)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(caCmd)
+	caCmd.AddCommand(caInitCmd)
+
+	caInitCmd.Flags().StringVarP(&caOutputDir, "output-dir", "o", "", "output directory for CA files (required)")
+	caInitCmd.Flags().IntVarP(&caValidDays, "valid-days", "d", security.DefaultCAValidDays, "certificate validity in days")
+	caInitCmd.MarkFlagRequired("output-dir")
+}

--- a/cmd/blazectl/cmd/cert.go
+++ b/cmd/blazectl/cmd/cert.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/good-yellow-bee/blazelog/internal/security"
+	"github.com/spf13/cobra"
+)
+
+var (
+	certCADir     string
+	certName      string
+	certOutputDir string
+	certValidDays int
+	certHosts     string
+)
+
+// certCmd represents the cert command group
+var certCmd = &cobra.Command{
+	Use:   "cert",
+	Short: "Certificate management",
+	Long:  `Commands for generating server and agent certificates.`,
+}
+
+// certServerCmd represents the cert server command
+var certServerCmd = &cobra.Command{
+	Use:   "server",
+	Short: "Generate a server certificate",
+	Long: `Generate a server certificate signed by the CA.
+
+The certificate will include localhost and any additional hosts
+specified with --hosts in the Subject Alternative Names (SAN).
+
+Example:
+  blazelog cert server --ca-dir ./certs --name server --out ./certs
+  blazelog cert server --ca-dir ./certs --name server --out ./certs --hosts blazelog.local,192.168.1.100`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateCertFlags(); err != nil {
+			return err
+		}
+
+		hosts := parseHosts(certHosts)
+
+		PrintVerbose("Generating server certificate...")
+		PrintVerbose("  CA directory: %s", certCADir)
+		PrintVerbose("  Name: %s", certName)
+		PrintVerbose("  Output directory: %s", certOutputDir)
+		PrintVerbose("  Validity: %d days", certValidDays)
+		PrintVerbose("  Additional hosts: %v", hosts)
+
+		if err := security.GenerateServerCert(certCADir, certName, certOutputDir, certValidDays, hosts); err != nil {
+			return fmt.Errorf("generate server certificate: %w", err)
+		}
+
+		fmt.Printf("Server certificate generated successfully:\n")
+		fmt.Printf("  Certificate: %s/%s.crt\n", certOutputDir, certName)
+		fmt.Printf("  Private key: %s/%s.key\n", certOutputDir, certName)
+		return nil
+	},
+}
+
+// certAgentCmd represents the cert agent command
+var certAgentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "Generate an agent certificate",
+	Long: `Generate an agent certificate signed by the CA.
+
+The certificate will include the local hostname in the
+Subject Alternative Names (SAN).
+
+Example:
+  blazelog cert agent --ca-dir ./certs --name agent1 --out ./certs
+  blazelog cert agent --ca-dir ./certs --name web-server-1 --out ./certs --valid-days 365`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateCertFlags(); err != nil {
+			return err
+		}
+
+		PrintVerbose("Generating agent certificate...")
+		PrintVerbose("  CA directory: %s", certCADir)
+		PrintVerbose("  Name: %s", certName)
+		PrintVerbose("  Output directory: %s", certOutputDir)
+		PrintVerbose("  Validity: %d days", certValidDays)
+
+		if err := security.GenerateAgentCert(certCADir, certName, certOutputDir, certValidDays); err != nil {
+			return fmt.Errorf("generate agent certificate: %w", err)
+		}
+
+		fmt.Printf("Agent certificate generated successfully:\n")
+		fmt.Printf("  Certificate: %s/%s.crt\n", certOutputDir, certName)
+		fmt.Printf("  Private key: %s/%s.key\n", certOutputDir, certName)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(certCmd)
+	certCmd.AddCommand(certServerCmd)
+	certCmd.AddCommand(certAgentCmd)
+
+	// Common flags for both server and agent
+	for _, cmd := range []*cobra.Command{certServerCmd, certAgentCmd} {
+		cmd.Flags().StringVar(&certCADir, "ca-dir", "", "directory containing CA certificate and key (required)")
+		cmd.Flags().StringVar(&certName, "name", "", "certificate name (required)")
+		cmd.Flags().StringVar(&certOutputDir, "out", "", "output directory for certificate files (required)")
+		cmd.Flags().IntVar(&certValidDays, "valid-days", security.DefaultCertValidDays, "certificate validity in days")
+		cmd.MarkFlagRequired("ca-dir")
+		cmd.MarkFlagRequired("name")
+		cmd.MarkFlagRequired("out")
+	}
+
+	// Server-specific flags
+	certServerCmd.Flags().StringVar(&certHosts, "hosts", "", "comma-separated list of additional hostnames/IPs for SAN")
+}
+
+func validateCertFlags() error {
+	if certCADir == "" {
+		return fmt.Errorf("--ca-dir is required")
+	}
+	if certName == "" {
+		return fmt.Errorf("--name is required")
+	}
+	if certOutputDir == "" {
+		return fmt.Errorf("--out is required")
+	}
+	return nil
+}
+
+func parseHosts(hosts string) []string {
+	if hosts == "" {
+		return nil
+	}
+	parts := strings.Split(hosts, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
+}

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -16,8 +16,17 @@ type Config struct {
 
 // ServerConfig contains server settings.
 type ServerConfig struct {
-	GRPCAddress string `yaml:"grpc_address"` // gRPC listen address (default: :9443)
-	HTTPAddress string `yaml:"http_address"` // HTTP listen address (default: :8080)
+	GRPCAddress string    `yaml:"grpc_address"` // gRPC listen address (default: :9443)
+	HTTPAddress string    `yaml:"http_address"` // HTTP listen address (default: :8080)
+	TLS         TLSConfig `yaml:"tls"`          // TLS configuration for mTLS
+}
+
+// TLSConfig contains TLS settings for the server.
+type TLSConfig struct {
+	Enabled      bool   `yaml:"enabled"`        // Enable mTLS
+	CertFile     string `yaml:"cert_file"`      // Server certificate file
+	KeyFile      string `yaml:"key_file"`       // Server private key file
+	ClientCAFile string `yaml:"client_ca_file"` // CA certificate for verifying client certs
 }
 
 // LoadConfig loads configuration from a YAML file.
@@ -62,6 +71,17 @@ func (c *Config) setDefaults() {
 func (c *Config) Validate() error {
 	if c.Server.GRPCAddress == "" {
 		return fmt.Errorf("server.grpc_address is required")
+	}
+	if c.Server.TLS.Enabled {
+		if c.Server.TLS.CertFile == "" {
+			return fmt.Errorf("server.tls.cert_file is required when TLS is enabled")
+		}
+		if c.Server.TLS.KeyFile == "" {
+			return fmt.Errorf("server.tls.key_file is required when TLS is enabled")
+		}
+		if c.Server.TLS.ClientCAFile == "" {
+			return fmt.Errorf("server.tls.client_ca_file is required when TLS is enabled")
+		}
 	}
 	return nil
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -77,8 +77,20 @@ func runServer(cmd *cobra.Command, args []string) error {
 		Verbose:     cfg.Verbose,
 	}
 
+	// Configure TLS if enabled
+	if cfg.Server.TLS.Enabled {
+		serverCfg.TLS = &server.TLSConfig{
+			CertFile:     cfg.Server.TLS.CertFile,
+			KeyFile:      cfg.Server.TLS.KeyFile,
+			ClientCAFile: cfg.Server.TLS.ClientCAFile,
+		}
+	}
+
 	// Create server
-	srv := server.New(serverCfg)
+	srv, err := server.New(serverCfg)
+	if err != nil {
+		return fmt.Errorf("create server: %w", err)
+	}
 
 	// Setup signal handling
 	ctx, cancel := context.WithCancel(context.Background())

--- a/configs/agent.yaml
+++ b/configs/agent.yaml
@@ -6,6 +6,24 @@ server:
   # BlazeLog server address (host:port)
   address: "localhost:9443"
 
+  # TLS configuration for mTLS (mutual TLS)
+  # Generate certificates with: blazelog ca init && blazelog cert agent
+  tls:
+    # Enable mTLS (set to false for insecure mode during development)
+    enabled: false
+
+    # Agent certificate file
+    # cert_file: "/etc/blazelog/certs/agent.crt"
+
+    # Agent private key file
+    # key_file: "/etc/blazelog/certs/agent.key"
+
+    # CA certificate for verifying server certificate
+    # ca_file: "/etc/blazelog/certs/ca.crt"
+
+    # Skip server certificate verification (dev only, NOT recommended for production)
+    # insecure_skip_verify: false
+
 # Agent settings
 agent:
   # Agent name (defaults to hostname if empty)

--- a/configs/server.yaml
+++ b/configs/server.yaml
@@ -9,3 +9,18 @@ server:
 
   # HTTP listen address for REST API (future)
   http_address: ":8080"
+
+  # TLS configuration for mTLS (mutual TLS)
+  # Generate certificates with: blazelog ca init && blazelog cert server
+  tls:
+    # Enable mTLS (set to false for insecure mode during development)
+    enabled: false
+
+    # Server certificate file
+    # cert_file: "/etc/blazelog/certs/server.crt"
+
+    # Server private key file
+    # key_file: "/etc/blazelog/certs/server.key"
+
+    # CA certificate for verifying client certificates
+    # client_ca_file: "/etc/blazelog/certs/ca.crt"

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -24,6 +24,7 @@ type AgentConfig struct {
 	Sources       []SourceConfig
 	Labels        map[string]string
 	Verbose       bool
+	TLS           *TLSConfig // nil = insecure mode
 }
 
 // Agent is the main BlazeLog agent.
@@ -58,7 +59,7 @@ func New(cfg *AgentConfig) (*Agent, error) {
 // Run starts the agent and blocks until the context is cancelled.
 func (a *Agent) Run(ctx context.Context) error {
 	// Connect to server
-	client, err := NewClient(a.config.ServerAddress)
+	client, err := NewClient(a.config.ServerAddress, a.config.TLS)
 	if err != nil {
 		return fmt.Errorf("create client: %w", err)
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -247,7 +247,7 @@ func TestClientRegister(t *testing.T) {
 	defer server.Stop()
 
 	// Create client
-	client, err := NewClient(lis.Addr().String())
+	client, err := NewClient(lis.Addr().String(), nil)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}

--- a/internal/security/ca.go
+++ b/internal/security/ca.go
@@ -1,0 +1,135 @@
+// Package security provides mTLS certificate management for BlazeLog.
+package security
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// DefaultCAValidDays is the default CA certificate validity (10 years).
+	DefaultCAValidDays = 3650
+	// DefaultCertValidDays is the default certificate validity (1 year).
+	DefaultCertValidDays = 365
+	// KeySize is the RSA key size in bits.
+	KeySize = 4096
+)
+
+// GenerateCA generates a new CA certificate and private key.
+// The certificate and key are written to outputDir as ca.crt and ca.key.
+func GenerateCA(outputDir string, validDays int) error {
+	if validDays <= 0 {
+		validDays = DefaultCAValidDays
+	}
+
+	// Generate RSA key pair
+	privateKey, err := rsa.GenerateKey(rand.Reader, KeySize)
+	if err != nil {
+		return fmt.Errorf("generate private key: %w", err)
+	}
+
+	// Create CA certificate template
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return fmt.Errorf("generate serial number: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"BlazeLog"},
+			CommonName:   "BlazeLog CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(0, 0, validDays),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            1,
+	}
+
+	// Self-sign the CA certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return fmt.Errorf("create certificate: %w", err)
+	}
+
+	// Ensure output directory exists
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+
+	// Write CA certificate
+	certPath := filepath.Join(outputDir, "ca.crt")
+	certFile, err := os.OpenFile(certPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("create cert file: %w", err)
+	}
+	defer certFile.Close()
+
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		return fmt.Errorf("encode certificate: %w", err)
+	}
+
+	// Write CA private key with restrictive permissions
+	keyPath := filepath.Join(outputDir, "ca.key")
+	keyFile, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("create key file: %w", err)
+	}
+	defer keyFile.Close()
+
+	keyDER := x509.MarshalPKCS1PrivateKey(privateKey)
+	if err := pem.Encode(keyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: keyDER}); err != nil {
+		return fmt.Errorf("encode private key: %w", err)
+	}
+
+	return nil
+}
+
+// LoadCA loads a CA certificate and private key from the given directory.
+func LoadCA(caDir string) (*x509.Certificate, *rsa.PrivateKey, error) {
+	// Load CA certificate
+	certPath := filepath.Join(caDir, "ca.crt")
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read CA certificate: %w", err)
+	}
+
+	block, _ := pem.Decode(certPEM)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, nil, fmt.Errorf("invalid CA certificate PEM")
+	}
+
+	caCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse CA certificate: %w", err)
+	}
+
+	// Load CA private key
+	keyPath := filepath.Join(caDir, "ca.key")
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read CA private key: %w", err)
+	}
+
+	block, _ = pem.Decode(keyPEM)
+	if block == nil || block.Type != "RSA PRIVATE KEY" {
+		return nil, nil, fmt.Errorf("invalid CA private key PEM")
+	}
+
+	caKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse CA private key: %w", err)
+	}
+
+	return caCert, caKey, nil
+}

--- a/internal/security/cert.go
+++ b/internal/security/cert.go
@@ -1,0 +1,134 @@
+package security
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// GenerateServerCert generates a server certificate signed by the CA.
+// The certificate includes localhost and the provided hosts in the SAN.
+func GenerateServerCert(caDir, name, outputDir string, validDays int, hosts []string) error {
+	return generateCert(caDir, name, outputDir, validDays, hosts, true)
+}
+
+// GenerateAgentCert generates an agent certificate signed by the CA.
+// The certificate includes the local hostname in the SAN.
+func GenerateAgentCert(caDir, name, outputDir string, validDays int) error {
+	hostname, _ := os.Hostname()
+	hosts := []string{hostname}
+	return generateCert(caDir, name, outputDir, validDays, hosts, false)
+}
+
+func generateCert(caDir, name, outputDir string, validDays int, hosts []string, isServer bool) error {
+	if validDays <= 0 {
+		validDays = DefaultCertValidDays
+	}
+
+	// Load CA
+	caCert, caKey, err := LoadCA(caDir)
+	if err != nil {
+		return fmt.Errorf("load CA: %w", err)
+	}
+
+	// Generate key pair
+	privateKey, err := rsa.GenerateKey(rand.Reader, KeySize)
+	if err != nil {
+		return fmt.Errorf("generate private key: %w", err)
+	}
+
+	// Create certificate template
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return fmt.Errorf("generate serial number: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"BlazeLog"},
+			CommonName:   name,
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().AddDate(0, 0, validDays),
+		KeyUsage:  x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+
+	// Set extended key usage based on cert type
+	if isServer {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		// Server certs always include localhost
+		hosts = appendUnique(hosts, "localhost", "127.0.0.1", "::1")
+	} else {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+
+	// Add SANs (Subject Alternative Names)
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	// Sign with CA
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &privateKey.PublicKey, caKey)
+	if err != nil {
+		return fmt.Errorf("create certificate: %w", err)
+	}
+
+	// Ensure output directory exists
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+
+	// Write certificate
+	certPath := filepath.Join(outputDir, name+".crt")
+	certFile, err := os.OpenFile(certPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("create cert file: %w", err)
+	}
+	defer certFile.Close()
+
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		return fmt.Errorf("encode certificate: %w", err)
+	}
+
+	// Write private key
+	keyPath := filepath.Join(outputDir, name+".key")
+	keyFile, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("create key file: %w", err)
+	}
+	defer keyFile.Close()
+
+	keyDER := x509.MarshalPKCS1PrivateKey(privateKey)
+	if err := pem.Encode(keyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: keyDER}); err != nil {
+		return fmt.Errorf("encode private key: %w", err)
+	}
+
+	return nil
+}
+
+func appendUnique(slice []string, items ...string) []string {
+	seen := make(map[string]bool)
+	for _, s := range slice {
+		seen[s] = true
+	}
+	for _, item := range items {
+		if !seen[item] {
+			slice = append(slice, item)
+			seen[item] = true
+		}
+	}
+	return slice
+}

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -1,0 +1,307 @@
+package security
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateCA(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	err := GenerateCA(tmpDir, 365)
+	if err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	// Check ca.crt exists
+	certPath := filepath.Join(tmpDir, "ca.crt")
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("failed to read ca.crt: %v", err)
+	}
+
+	// Check ca.key exists
+	keyPath := filepath.Join(tmpDir, "ca.key")
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("failed to read ca.key: %v", err)
+	}
+
+	// Verify certificate is valid
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatal("failed to decode certificate PEM")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	if !cert.IsCA {
+		t.Error("certificate is not a CA")
+	}
+
+	if cert.Subject.CommonName != "BlazeLog CA" {
+		t.Errorf("unexpected CN: got %s, want BlazeLog CA", cert.Subject.CommonName)
+	}
+
+	// Verify key is valid
+	block, _ = pem.Decode(keyPEM)
+	if block == nil {
+		t.Fatal("failed to decode key PEM")
+	}
+
+	_, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse private key: %v", err)
+	}
+
+	// Check key file permissions
+	keyInfo, _ := os.Stat(keyPath)
+	if keyInfo.Mode().Perm() != 0600 {
+		t.Errorf("ca.key permissions: got %o, want 0600", keyInfo.Mode().Perm())
+	}
+}
+
+func TestLoadCA(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Generate CA first
+	err := GenerateCA(tmpDir, 365)
+	if err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	// Load CA
+	cert, key, err := LoadCA(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadCA failed: %v", err)
+	}
+
+	if !cert.IsCA {
+		t.Error("loaded certificate is not a CA")
+	}
+
+	if key == nil {
+		t.Error("loaded key is nil")
+	}
+}
+
+func TestGenerateServerCert(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Generate CA first
+	err := GenerateCA(tmpDir, 365)
+	if err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	// Generate server cert
+	hosts := []string{"blazelog.local", "192.168.1.100"}
+	err = GenerateServerCert(tmpDir, "server", tmpDir, 365, hosts)
+	if err != nil {
+		t.Fatalf("GenerateServerCert failed: %v", err)
+	}
+
+	// Check server.crt exists
+	certPath := filepath.Join(tmpDir, "server.crt")
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("failed to read server.crt: %v", err)
+	}
+
+	// Verify certificate
+	block, _ := pem.Decode(certPEM)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	if cert.Subject.CommonName != "server" {
+		t.Errorf("unexpected CN: got %s, want server", cert.Subject.CommonName)
+	}
+
+	// Check SANs include localhost
+	if !containsString(cert.DNSNames, "localhost") {
+		t.Error("DNS names should include localhost")
+	}
+	if !containsString(cert.DNSNames, "blazelog.local") {
+		t.Error("DNS names should include blazelog.local")
+	}
+
+	// Check ExtKeyUsage
+	if len(cert.ExtKeyUsage) == 0 || cert.ExtKeyUsage[0] != x509.ExtKeyUsageServerAuth {
+		t.Error("server cert should have ServerAuth extended key usage")
+	}
+}
+
+func TestGenerateAgentCert(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Generate CA first
+	err := GenerateCA(tmpDir, 365)
+	if err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	// Generate agent cert
+	err = GenerateAgentCert(tmpDir, "agent1", tmpDir, 365)
+	if err != nil {
+		t.Fatalf("GenerateAgentCert failed: %v", err)
+	}
+
+	// Check agent1.crt exists
+	certPath := filepath.Join(tmpDir, "agent1.crt")
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("failed to read agent1.crt: %v", err)
+	}
+
+	// Verify certificate
+	block, _ := pem.Decode(certPEM)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	if cert.Subject.CommonName != "agent1" {
+		t.Errorf("unexpected CN: got %s, want agent1", cert.Subject.CommonName)
+	}
+
+	// Check ExtKeyUsage
+	if len(cert.ExtKeyUsage) == 0 || cert.ExtKeyUsage[0] != x509.ExtKeyUsageClientAuth {
+		t.Error("agent cert should have ClientAuth extended key usage")
+	}
+}
+
+func TestLoadServerTLS(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Generate CA and server cert
+	err := GenerateCA(tmpDir, 365)
+	if err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	err = GenerateServerCert(tmpDir, "server", tmpDir, 365, nil)
+	if err != nil {
+		t.Fatalf("GenerateServerCert failed: %v", err)
+	}
+
+	// Load server TLS
+	cfg := &ServerTLSConfig{
+		CertFile:     filepath.Join(tmpDir, "server.crt"),
+		KeyFile:      filepath.Join(tmpDir, "server.key"),
+		ClientCAFile: filepath.Join(tmpDir, "ca.crt"),
+	}
+
+	creds, err := LoadServerTLS(cfg)
+	if err != nil {
+		t.Fatalf("LoadServerTLS failed: %v", err)
+	}
+
+	if creds == nil {
+		t.Error("credentials should not be nil")
+	}
+}
+
+func TestLoadClientTLS(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Generate CA and agent cert
+	err := GenerateCA(tmpDir, 365)
+	if err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	err = GenerateAgentCert(tmpDir, "agent1", tmpDir, 365)
+	if err != nil {
+		t.Fatalf("GenerateAgentCert failed: %v", err)
+	}
+
+	// Load client TLS
+	cfg := &ClientTLSConfig{
+		CertFile: filepath.Join(tmpDir, "agent1.crt"),
+		KeyFile:  filepath.Join(tmpDir, "agent1.key"),
+		CAFile:   filepath.Join(tmpDir, "ca.crt"),
+	}
+
+	creds, err := LoadClientTLS(cfg)
+	if err != nil {
+		t.Fatalf("LoadClientTLS failed: %v", err)
+	}
+
+	if creds == nil {
+		t.Error("credentials should not be nil")
+	}
+}
+
+func TestLoadClientTLS_InsecureSkipVerify(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Generate CA and agent cert
+	err := GenerateCA(tmpDir, 365)
+	if err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	err = GenerateAgentCert(tmpDir, "agent1", tmpDir, 365)
+	if err != nil {
+		t.Fatalf("GenerateAgentCert failed: %v", err)
+	}
+
+	// Load client TLS with insecure skip verify
+	cfg := &ClientTLSConfig{
+		CertFile:           filepath.Join(tmpDir, "agent1.crt"),
+		KeyFile:            filepath.Join(tmpDir, "agent1.key"),
+		InsecureSkipVerify: true,
+	}
+
+	creds, err := LoadClientTLS(cfg)
+	if err != nil {
+		t.Fatalf("LoadClientTLS failed: %v", err)
+	}
+
+	if creds == nil {
+		t.Error("credentials should not be nil")
+	}
+}
+
+func TestLoadServerTLS_MissingCert(t *testing.T) {
+	cfg := &ServerTLSConfig{
+		CertFile:     "/nonexistent/server.crt",
+		KeyFile:      "/nonexistent/server.key",
+		ClientCAFile: "/nonexistent/ca.crt",
+	}
+
+	_, err := LoadServerTLS(cfg)
+	if err == nil {
+		t.Error("LoadServerTLS should fail with missing cert")
+	}
+}
+
+func TestLoadClientTLS_MissingCert(t *testing.T) {
+	cfg := &ClientTLSConfig{
+		CertFile: "/nonexistent/agent.crt",
+		KeyFile:  "/nonexistent/agent.key",
+		CAFile:   "/nonexistent/ca.crt",
+	}
+
+	_, err := LoadClientTLS(cfg)
+	if err == nil {
+		t.Error("LoadClientTLS should fail with missing cert")
+	}
+}
+
+func containsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/security/tls.go
+++ b/internal/security/tls.go
@@ -1,0 +1,87 @@
+package security
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"google.golang.org/grpc/credentials"
+)
+
+// ServerTLSConfig holds server TLS configuration.
+type ServerTLSConfig struct {
+	CertFile     string // Server certificate file
+	KeyFile      string // Server private key file
+	ClientCAFile string // CA certificate for verifying client certs
+}
+
+// ClientTLSConfig holds client TLS configuration.
+type ClientTLSConfig struct {
+	CertFile           string // Client certificate file
+	KeyFile            string // Client private key file
+	CAFile             string // CA certificate for verifying server cert
+	InsecureSkipVerify bool   // Skip server certificate verification (dev only)
+}
+
+// LoadServerTLS loads TLS credentials for the gRPC server.
+// Requires client certificate verification (mTLS).
+func LoadServerTLS(cfg *ServerTLSConfig) (credentials.TransportCredentials, error) {
+	// Load server certificate and key
+	serverCert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("load server certificate: %w", err)
+	}
+
+	// Load CA certificate for client verification
+	caCert, err := os.ReadFile(cfg.ClientCAFile)
+	if err != nil {
+		return nil, fmt.Errorf("read client CA certificate: %w", err)
+	}
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to add client CA certificate")
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    caPool,
+		MinVersion:   tls.VersionTLS13,
+	}
+
+	return credentials.NewTLS(tlsConfig), nil
+}
+
+// LoadClientTLS loads TLS credentials for the gRPC client.
+// Verifies server certificate and presents client certificate for mTLS.
+func LoadClientTLS(cfg *ClientTLSConfig) (credentials.TransportCredentials, error) {
+	// Load client certificate and key
+	clientCert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("load client certificate: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates:       []tls.Certificate{clientCert},
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		MinVersion:         tls.VersionTLS13,
+	}
+
+	// Load CA certificate for server verification (unless skipping)
+	if !cfg.InsecureSkipVerify {
+		caCert, err := os.ReadFile(cfg.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("read CA certificate: %w", err)
+		}
+
+		caPool := x509.NewCertPool()
+		if !caPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to add CA certificate")
+		}
+		tlsConfig.RootCAs = caPool
+	}
+
+	return credentials.NewTLS(tlsConfig), nil
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -26,7 +26,10 @@ func TestServerIntegration(t *testing.T) {
 		GRPCAddress: addr,
 		Verbose:     true,
 	}
-	srv := New(cfg)
+	srv, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New server failed: %v", err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/server/server_tls_test.go
+++ b/internal/server/server_tls_test.go
@@ -1,0 +1,273 @@
+package server
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/agent"
+	blazelogv1 "github.com/good-yellow-bee/blazelog/internal/proto/blazelog/v1"
+	"github.com/good-yellow-bee/blazelog/internal/security"
+)
+
+func TestServerClientMTLS(t *testing.T) {
+	// Setup test certificates
+	tmpDir := t.TempDir()
+
+	// Generate CA
+	if err := security.GenerateCA(tmpDir, 365); err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	// Generate server cert
+	if err := security.GenerateServerCert(tmpDir, "server", tmpDir, 365, nil); err != nil {
+		t.Fatalf("GenerateServerCert failed: %v", err)
+	}
+
+	// Generate agent cert
+	if err := security.GenerateAgentCert(tmpDir, "agent", tmpDir, 365); err != nil {
+		t.Fatalf("GenerateAgentCert failed: %v", err)
+	}
+
+	// Find free port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	// Create server with TLS
+	serverCfg := &Config{
+		GRPCAddress: addr,
+		Verbose:     true,
+		TLS: &TLSConfig{
+			CertFile:     filepath.Join(tmpDir, "server.crt"),
+			KeyFile:      filepath.Join(tmpDir, "server.key"),
+			ClientCAFile: filepath.Join(tmpDir, "ca.crt"),
+		},
+	}
+
+	srv, err := New(serverCfg)
+	if err != nil {
+		t.Fatalf("New server failed: %v", err)
+	}
+
+	// Start server
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- srv.Run(ctx)
+	}()
+
+	// Give server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Create client with TLS
+	clientTLS := &agent.TLSConfig{
+		CertFile: filepath.Join(tmpDir, "agent.crt"),
+		KeyFile:  filepath.Join(tmpDir, "agent.key"),
+		CAFile:   filepath.Join(tmpDir, "ca.crt"),
+	}
+
+	client, err := agent.NewClient(addr, clientTLS)
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	defer client.Close()
+
+	// Test registration
+	clientCtx, clientCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer clientCancel()
+
+	agentInfo := &blazelogv1.AgentInfo{
+		Name:     "test-agent",
+		Hostname: "localhost",
+		Version:  "test",
+		Os:       "linux",
+		Arch:     "amd64",
+	}
+
+	resp, err := client.Register(clientCtx, agentInfo)
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	if !resp.Success {
+		t.Errorf("registration not successful: %s", resp.ErrorMessage)
+	}
+
+	if resp.AgentId == "" {
+		t.Error("expected non-empty agent ID")
+	}
+
+	// Shutdown
+	cancel()
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Logf("server exited with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("server did not shutdown in time")
+	}
+}
+
+func TestServerRejectsInvalidClientCert(t *testing.T) {
+	// Setup test certificates
+	tmpDir := t.TempDir()
+
+	// Generate CA
+	if err := security.GenerateCA(tmpDir, 365); err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	// Generate server cert
+	if err := security.GenerateServerCert(tmpDir, "server", tmpDir, 365, nil); err != nil {
+		t.Fatalf("GenerateServerCert failed: %v", err)
+	}
+
+	// Generate a DIFFERENT CA and agent cert (should be rejected)
+	otherCADir := t.TempDir()
+	if err := security.GenerateCA(otherCADir, 365); err != nil {
+		t.Fatalf("GenerateCA (other) failed: %v", err)
+	}
+	if err := security.GenerateAgentCert(otherCADir, "bad-agent", otherCADir, 365); err != nil {
+		t.Fatalf("GenerateAgentCert (other) failed: %v", err)
+	}
+
+	// Find free port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	// Create server with TLS (using first CA)
+	serverCfg := &Config{
+		GRPCAddress: addr,
+		Verbose:     false,
+		TLS: &TLSConfig{
+			CertFile:     filepath.Join(tmpDir, "server.crt"),
+			KeyFile:      filepath.Join(tmpDir, "server.key"),
+			ClientCAFile: filepath.Join(tmpDir, "ca.crt"),
+		},
+	}
+
+	srv, err := New(serverCfg)
+	if err != nil {
+		t.Fatalf("New server failed: %v", err)
+	}
+
+	// Start server
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		srv.Run(ctx)
+	}()
+
+	// Give server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Create client with cert from DIFFERENT CA (should fail)
+	clientTLS := &agent.TLSConfig{
+		CertFile:           filepath.Join(otherCADir, "bad-agent.crt"),
+		KeyFile:            filepath.Join(otherCADir, "bad-agent.key"),
+		CAFile:             filepath.Join(tmpDir, "ca.crt"), // Use server's CA to verify server
+		InsecureSkipVerify: true,                            // Skip server verification for this test
+	}
+
+	client, err := agent.NewClient(addr, clientTLS)
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	defer client.Close()
+
+	// Test registration - should fail due to certificate verification
+	clientCtx, clientCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer clientCancel()
+
+	agentInfo := &blazelogv1.AgentInfo{
+		Name:     "bad-agent",
+		Hostname: "localhost",
+		Version:  "test",
+		Os:       "linux",
+		Arch:     "amd64",
+	}
+
+	_, err = client.Register(clientCtx, agentInfo)
+	if err == nil {
+		t.Error("expected Register to fail with invalid client certificate")
+	}
+
+	cancel()
+}
+
+func TestServerInsecureMode(t *testing.T) {
+	// Find free port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	// Create server WITHOUT TLS
+	serverCfg := &Config{
+		GRPCAddress: addr,
+		Verbose:     false,
+		TLS:         nil, // No TLS
+	}
+
+	srv, err := New(serverCfg)
+	if err != nil {
+		t.Fatalf("New server failed: %v", err)
+	}
+
+	// Start server
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		srv.Run(ctx)
+	}()
+
+	// Give server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Create client WITHOUT TLS
+	client, err := agent.NewClient(addr, nil)
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	defer client.Close()
+
+	// Test registration
+	clientCtx, clientCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer clientCancel()
+
+	agentInfo := &blazelogv1.AgentInfo{
+		Name:     "insecure-agent",
+		Hostname: "localhost",
+		Version:  "test",
+		Os:       "linux",
+		Arch:     "amd64",
+	}
+
+	resp, err := client.Register(clientCtx, agentInfo)
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	if !resp.Success {
+		t.Errorf("registration not successful: %s", resp.ErrorMessage)
+	}
+
+	cancel()
+}


### PR DESCRIPTION
## Summary

Implements mTLS (mutual TLS) security for agent-server gRPC communication, completing Milestone 15.

### Changes

- **New `internal/security/` package:**
  - CA certificate generation (RSA 4096-bit keys, 10-year validity)
  - Server/agent certificate generation (1-year validity)
  - TLS credential loading for gRPC server/client

- **New CLI commands:**
  - `blazectl ca init --output-dir ./certs` - Generate CA certificate
  - `blazectl cert server --ca-dir ./certs --name server --out ./certs` - Generate server cert
  - `blazectl cert agent --ca-dir ./certs --name agent1 --out ./certs` - Generate agent cert

- **Config extensions:**
  - Server config: `tls.enabled`, `cert_file`, `key_file`, `client_ca_file`
  - Agent config: `tls.enabled`, `cert_file`, `key_file`, `ca_file`, `insecure_skip_verify`

- **gRPC integration:**
  - Server: Requires client cert verification when TLS enabled
  - Client: Verifies server cert and presents client cert for mTLS
  - Backward compatible: insecure mode if TLS not configured

### Test plan

- [x] Unit tests for CA/cert generation
- [x] Unit tests for TLS credential loading
- [x] Integration test: mTLS connection works
- [x] Integration test: Invalid client cert rejected
- [x] Integration test: Insecure mode still works

Closes #15