### PR TITLE
Fix window memory leak in alerting engine

### DIFF
--- a/internal/alerting/engine.go
+++ b/internal/alerting/engine.go
@@ -236,7 +236,7 @@ func (e *Engine) RemoveRule(name string) bool {
 	for i, rule := range e.rules {
 		if rule.Name == name {
 			e.rules = append(e.rules[:i], e.rules[i+1:]...)
-			e.windows.Reset(name)
+			e.windows.Delete(name) // Delete window to prevent memory leak
 			e.cooldown.Clear(name)
 			return true
 		}
@@ -280,7 +280,7 @@ func (e *Engine) ReloadRules(rules []*Rule) error {
 	defer e.mu.Unlock()
 
 	e.rules = rules
-	e.windows.ResetAll()
+	e.windows.DeleteAll() // Delete all windows to prevent memory leaks
 	e.cooldown.ClearAll()
 
 	return nil

--- a/internal/alerting/window.go
+++ b/internal/alerting/window.go
@@ -133,7 +133,7 @@ func (wm *WindowManager) Get(ruleName string) *SlidingWindow {
 	return wm.windows[ruleName]
 }
 
-// Reset clears a specific window.
+// Reset clears a specific window's events without removing the window.
 func (wm *WindowManager) Reset(ruleName string) {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
@@ -143,7 +143,16 @@ func (wm *WindowManager) Reset(ruleName string) {
 	}
 }
 
-// ResetAll clears all windows.
+// Delete removes a window from the manager entirely.
+// Use this when removing a rule to prevent memory leaks.
+func (wm *WindowManager) Delete(ruleName string) {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+
+	delete(wm.windows, ruleName)
+}
+
+// ResetAll clears all windows' events without removing them.
 func (wm *WindowManager) ResetAll() {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
@@ -151,6 +160,15 @@ func (wm *WindowManager) ResetAll() {
 	for _, w := range wm.windows {
 		w.Reset()
 	}
+}
+
+// DeleteAll removes all windows from the manager.
+// Use this when reloading rules to prevent memory leaks.
+func (wm *WindowManager) DeleteAll() {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+
+	wm.windows = make(map[string]*SlidingWindow)
 }
 
 // Count returns the event count for a rule.


### PR DESCRIPTION
## Summary
- Fix memory leak where `WindowManager` kept window objects in map after rule removal
- Add `Delete()` and `DeleteAll()` methods for proper cleanup
- Update `RemoveRule()` and `ReloadRules()` to delete windows instead of just resetting them

## Problem
When rules were removed via `RemoveRule()` or replaced via `ReloadRules()`, the code only called `Reset()` on windows which cleared events but kept the window object in the map. This caused memory bloat over time as dead windows accumulated.

## Solution
- Added `WindowManager.Delete(ruleName)` to remove a window from the map entirely
- Added `WindowManager.DeleteAll()` to remove all windows (for rule reloads)
- Changed `Engine.RemoveRule()` to call `Delete()` instead of `Reset()`
- Changed `Engine.ReloadRules()` to call `DeleteAll()` instead of `ResetAll()`

## Test plan
- [x] Added `TestWindowManagerDelete` - verifies single window deletion
- [x] Added `TestWindowManagerDeleteAll` - verifies all windows deleted
- [x] Added `TestEngineRemoveRuleDeletesWindow` - verifies engine cleanup on rule removal
- [x] Added `TestEngineReloadRulesDeletesWindows` - verifies engine cleanup on reload
- [x] All existing tests pass