### PR TITLE
22 - API Auth & Users

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -14,7 +14,19 @@ type Config struct {
 	Database       DatabaseConfig    `yaml:"database"`        // Database configuration
 	ClickHouse     ClickHouseConfig  `yaml:"clickhouse"`      // ClickHouse log storage configuration
 	SSHConnections []SSHConnection   `yaml:"ssh_connections"` // SSH connections for remote log collection
+	Auth           AuthConfig        `yaml:"auth"`            // Authentication configuration
 	Verbose        bool              `yaml:"-"`               // set via CLI flag
+}
+
+// AuthConfig contains authentication settings.
+type AuthConfig struct {
+	JWTSecretEnv     string `yaml:"jwt_secret_env"`      // Env var name for JWT secret (default: BLAZELOG_JWT_SECRET)
+	AccessTokenTTL   string `yaml:"access_token_ttl"`    // Access token TTL (default: 15m)
+	RefreshTokenTTL  string `yaml:"refresh_token_ttl"`   // Refresh token TTL (default: 168h / 7 days)
+	RateLimitPerIP   int    `yaml:"rate_limit_per_ip"`   // Login rate limit per IP (default: 5/min)
+	RateLimitPerUser int    `yaml:"rate_limit_per_user"` // API rate limit per user (default: 100/min)
+	LockoutThreshold int    `yaml:"lockout_threshold"`   // Failed attempts before lockout (default: 5)
+	LockoutDuration  string `yaml:"lockout_duration"`    // Lockout duration (default: 15m)
 }
 
 // ClickHouseConfig contains ClickHouse settings.
@@ -134,6 +146,28 @@ func (c *Config) setDefaults() {
 	}
 	if c.ClickHouse.RetentionDays == 0 {
 		c.ClickHouse.RetentionDays = 30
+	}
+	// Auth defaults
+	if c.Auth.JWTSecretEnv == "" {
+		c.Auth.JWTSecretEnv = "BLAZELOG_JWT_SECRET"
+	}
+	if c.Auth.AccessTokenTTL == "" {
+		c.Auth.AccessTokenTTL = "15m"
+	}
+	if c.Auth.RefreshTokenTTL == "" {
+		c.Auth.RefreshTokenTTL = "168h" // 7 days
+	}
+	if c.Auth.RateLimitPerIP == 0 {
+		c.Auth.RateLimitPerIP = 5
+	}
+	if c.Auth.RateLimitPerUser == 0 {
+		c.Auth.RateLimitPerUser = 100
+	}
+	if c.Auth.LockoutThreshold == 0 {
+		c.Auth.LockoutThreshold = 5
+	}
+	if c.Auth.LockoutDuration == "" {
+		c.Auth.LockoutDuration = "15m"
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,10 @@ require (
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/go-chi/chi/v5 v5.2.3 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,11 +13,15 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
+github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=
 github.com/go-faster/city v1.0.1/go.mod h1:jKcUJId49qdW3L1qKHH/3wPeUstCVpVSXTM6vO3VcTw=
 github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=
 github.com/go-faster/errors v0.7.1/go.mod h1:5ySTjWFiphBs07IKuiL69nxdfd5+fzh1u7FPGZP2quo=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,0 +1,116 @@
+// Package api provides the HTTP REST API server.
+package api
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/storage"
+)
+
+// Config contains HTTP API server configuration.
+type Config struct {
+	Address          string
+	JWTSecret        []byte
+	AccessTokenTTL   time.Duration
+	RefreshTokenTTL  time.Duration
+	RateLimitPerIP   int
+	RateLimitPerUser int
+	LockoutThreshold int
+	LockoutDuration  time.Duration
+	Verbose          bool
+}
+
+// SetDefaults applies default values for missing configuration.
+func (c *Config) SetDefaults() {
+	if c.Address == "" {
+		c.Address = ":8080"
+	}
+	if c.AccessTokenTTL == 0 {
+		c.AccessTokenTTL = 15 * time.Minute
+	}
+	if c.RefreshTokenTTL == 0 {
+		c.RefreshTokenTTL = 7 * 24 * time.Hour // 7 days
+	}
+	if c.RateLimitPerIP == 0 {
+		c.RateLimitPerIP = 5 // 5 requests per minute
+	}
+	if c.RateLimitPerUser == 0 {
+		c.RateLimitPerUser = 100 // 100 requests per minute
+	}
+	if c.LockoutThreshold == 0 {
+		c.LockoutThreshold = 5 // 5 failed attempts
+	}
+	if c.LockoutDuration == 0 {
+		c.LockoutDuration = 15 * time.Minute
+	}
+}
+
+// Server is the HTTP API server.
+type Server struct {
+	config  *Config
+	storage storage.Storage
+	server  *http.Server
+}
+
+// New creates a new API server.
+func New(cfg *Config, store storage.Storage) (*Server, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	if store == nil {
+		return nil, fmt.Errorf("storage is required")
+	}
+	if len(cfg.JWTSecret) == 0 {
+		return nil, fmt.Errorf("JWT secret is required")
+	}
+
+	cfg.SetDefaults()
+
+	s := &Server{
+		config:  cfg,
+		storage: store,
+	}
+
+	router := s.setupRouter()
+
+	s.server = &http.Server{
+		Addr:         cfg.Address,
+		Handler:      router,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	return s, nil
+}
+
+// Run starts the HTTP server and blocks until context is cancelled.
+func (s *Server) Run(ctx context.Context) error {
+	errChan := make(chan error, 1)
+
+	go func() {
+		log.Printf("HTTP API listening on %s", s.config.Address)
+		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errChan <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.Printf("shutting down HTTP API server...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return s.server.Shutdown(shutdownCtx)
+	case err := <-errChan:
+		return err
+	}
+}
+
+// Address returns the configured listen address.
+func (s *Server) Address() string {
+	return s.config.Address
+}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,375 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+	"github.com/good-yellow-bee/blazelog/internal/storage"
+)
+
+// testServer creates a test server with in-memory SQLite
+func testServer(t *testing.T) (*Server, storage.Storage, func()) {
+	t.Helper()
+
+	// Create temp DB
+	tmpFile, err := os.CreateTemp("", "blazelog-test-*.db")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	masterKey := []byte("test-master-key-32-bytes-long!!")
+	store := storage.NewSQLiteStorage(tmpFile.Name(), masterKey)
+	if err := store.Open(); err != nil {
+		os.Remove(tmpFile.Name())
+		t.Fatalf("open storage: %v", err)
+	}
+	if err := store.Migrate(); err != nil {
+		store.Close()
+		os.Remove(tmpFile.Name())
+		t.Fatalf("migrate storage: %v", err)
+	}
+
+	cfg := &Config{
+		Address:          ":0",
+		JWTSecret:        []byte("test-jwt-secret-32-bytes-long!!"),
+		AccessTokenTTL:   15 * time.Minute,
+		RefreshTokenTTL:  24 * time.Hour,
+		RateLimitPerIP:   100,
+		RateLimitPerUser: 100,
+		LockoutThreshold: 5,
+		LockoutDuration:  15 * time.Minute,
+		Verbose:          false,
+	}
+
+	srv, err := New(cfg, store)
+	if err != nil {
+		store.Close()
+		os.Remove(tmpFile.Name())
+		t.Fatalf("create server: %v", err)
+	}
+
+	cleanup := func() {
+		store.Close()
+		os.Remove(tmpFile.Name())
+	}
+
+	return srv, store, cleanup
+}
+
+// createTestUser creates a user in the database for testing
+func createTestUser(t *testing.T, store storage.Storage, username, password string, role models.Role) *models.User {
+	t.Helper()
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+
+	now := time.Now()
+	user := &models.User{
+		ID:           "test-" + username,
+		Username:     username,
+		Email:        username + "@test.com",
+		PasswordHash: string(hash),
+		Role:         role,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	if err := store.Users().Create(context.Background(), user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	return user
+}
+
+// handler returns the HTTP handler for the server
+func handler(srv *Server) http.Handler {
+	return srv.server.Handler
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	srv, _, cleanup := testServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	rec := httptest.NewRecorder()
+
+	handler(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestLogin_Success(t *testing.T) {
+	srv, store, cleanup := testServer(t)
+	defer cleanup()
+
+	createTestUser(t, store, "testuser", "TestPassword123!", models.RoleViewer)
+
+	body := `{"username":"testuser","password":"TestPassword123!"}`
+	req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+			ExpiresIn    int    `json:"expires_in"`
+			TokenType    string `json:"token_type"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if resp.Data.AccessToken == "" {
+		t.Error("expected non-empty access_token")
+	}
+	if resp.Data.RefreshToken == "" {
+		t.Error("expected non-empty refresh_token")
+	}
+	if resp.Data.TokenType != "Bearer" {
+		t.Errorf("token_type = %q, want Bearer", resp.Data.TokenType)
+	}
+}
+
+func TestLogin_InvalidCredentials(t *testing.T) {
+	srv, store, cleanup := testServer(t)
+	defer cleanup()
+
+	createTestUser(t, store, "testuser", "TestPassword123!", models.RoleViewer)
+
+	body := `{"username":"testuser","password":"wrongpassword"}`
+	req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestLogin_UserNotFound(t *testing.T) {
+	srv, _, cleanup := testServer(t)
+	defer cleanup()
+
+	body := `{"username":"nonexistent","password":"password"}`
+	req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRefresh_Success(t *testing.T) {
+	srv, store, cleanup := testServer(t)
+	defer cleanup()
+
+	createTestUser(t, store, "testuser", "TestPassword123!", models.RoleViewer)
+
+	// First login
+	loginBody := `{"username":"testuser","password":"TestPassword123!"}`
+	loginReq := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewBufferString(loginBody))
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginRec := httptest.NewRecorder()
+	handler(srv).ServeHTTP(loginRec, loginReq)
+
+	var loginResp struct {
+		Data struct {
+			RefreshToken string `json:"refresh_token"`
+		} `json:"data"`
+	}
+	json.NewDecoder(loginRec.Body).Decode(&loginResp)
+
+	// Refresh
+	refreshBody := `{"refresh_token":"` + loginResp.Data.RefreshToken + `"}`
+	refreshReq := httptest.NewRequest("POST", "/api/v1/auth/refresh", bytes.NewBufferString(refreshBody))
+	refreshReq.Header.Set("Content-Type", "application/json")
+	refreshRec := httptest.NewRecorder()
+	handler(srv).ServeHTTP(refreshRec, refreshReq)
+
+	if refreshRec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d; body: %s", refreshRec.Code, http.StatusOK, refreshRec.Body.String())
+	}
+}
+
+func TestProtectedEndpoint_NoToken(t *testing.T) {
+	srv, _, cleanup := testServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/api/v1/users/me", nil)
+	rec := httptest.NewRecorder()
+
+	handler(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestProtectedEndpoint_WithToken(t *testing.T) {
+	srv, store, cleanup := testServer(t)
+	defer cleanup()
+
+	createTestUser(t, store, "testuser", "TestPassword123!", models.RoleViewer)
+
+	// Login
+	loginBody := `{"username":"testuser","password":"TestPassword123!"}`
+	loginReq := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewBufferString(loginBody))
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginRec := httptest.NewRecorder()
+	handler(srv).ServeHTTP(loginRec, loginReq)
+
+	var loginResp struct {
+		Data struct {
+			AccessToken string `json:"access_token"`
+		} `json:"data"`
+	}
+	json.NewDecoder(loginRec.Body).Decode(&loginResp)
+
+	// Access protected endpoint
+	req := httptest.NewRequest("GET", "/api/v1/users/me", nil)
+	req.Header.Set("Authorization", "Bearer "+loginResp.Data.AccessToken)
+	rec := httptest.NewRecorder()
+
+	handler(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+func TestAdminEndpoint_NonAdmin(t *testing.T) {
+	srv, store, cleanup := testServer(t)
+	defer cleanup()
+
+	createTestUser(t, store, "viewer", "TestPassword123!", models.RoleViewer)
+
+	// Login as viewer
+	loginBody := `{"username":"viewer","password":"TestPassword123!"}`
+	loginReq := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewBufferString(loginBody))
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginRec := httptest.NewRecorder()
+	handler(srv).ServeHTTP(loginRec, loginReq)
+
+	var loginResp struct {
+		Data struct {
+			AccessToken string `json:"access_token"`
+		} `json:"data"`
+	}
+	json.NewDecoder(loginRec.Body).Decode(&loginResp)
+
+	// Try to access admin endpoint
+	req := httptest.NewRequest("GET", "/api/v1/users", nil)
+	req.Header.Set("Authorization", "Bearer "+loginResp.Data.AccessToken)
+	rec := httptest.NewRecorder()
+
+	handler(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestAdminEndpoint_Admin(t *testing.T) {
+	srv, store, cleanup := testServer(t)
+	defer cleanup()
+
+	createTestUser(t, store, "admin", "TestPassword123!", models.RoleAdmin)
+
+	// Login as admin
+	loginBody := `{"username":"admin","password":"TestPassword123!"}`
+	loginReq := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewBufferString(loginBody))
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginRec := httptest.NewRecorder()
+	handler(srv).ServeHTTP(loginRec, loginReq)
+
+	var loginResp struct {
+		Data struct {
+			AccessToken string `json:"access_token"`
+		} `json:"data"`
+	}
+	json.NewDecoder(loginRec.Body).Decode(&loginResp)
+
+	// Access admin endpoint
+	req := httptest.NewRequest("GET", "/api/v1/users", nil)
+	req.Header.Set("Authorization", "Bearer "+loginResp.Data.AccessToken)
+	rec := httptest.NewRecorder()
+
+	handler(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+func TestLogout(t *testing.T) {
+	srv, store, cleanup := testServer(t)
+	defer cleanup()
+
+	createTestUser(t, store, "testuser", "TestPassword123!", models.RoleViewer)
+
+	// Login
+	loginBody := `{"username":"testuser","password":"TestPassword123!"}`
+	loginReq := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewBufferString(loginBody))
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginRec := httptest.NewRecorder()
+	handler(srv).ServeHTTP(loginRec, loginReq)
+
+	var loginResp struct {
+		Data struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		} `json:"data"`
+	}
+	json.NewDecoder(loginRec.Body).Decode(&loginResp)
+
+	// Logout
+	logoutBody := `{"refresh_token":"` + loginResp.Data.RefreshToken + `"}`
+	logoutReq := httptest.NewRequest("POST", "/api/v1/auth/logout", bytes.NewBufferString(logoutBody))
+	logoutReq.Header.Set("Content-Type", "application/json")
+	logoutReq.Header.Set("Authorization", "Bearer "+loginResp.Data.AccessToken)
+	logoutRec := httptest.NewRecorder()
+
+	handler(srv).ServeHTTP(logoutRec, logoutReq)
+
+	if logoutRec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", logoutRec.Code, http.StatusNoContent)
+	}
+
+	// Try to refresh with revoked token
+	refreshBody := `{"refresh_token":"` + loginResp.Data.RefreshToken + `"}`
+	refreshReq := httptest.NewRequest("POST", "/api/v1/auth/refresh", bytes.NewBufferString(refreshBody))
+	refreshReq.Header.Set("Content-Type", "application/json")
+	refreshRec := httptest.NewRecorder()
+	handler(srv).ServeHTTP(refreshRec, refreshReq)
+
+	if refreshRec.Code != http.StatusUnauthorized {
+		t.Errorf("refresh after logout: status = %d, want %d", refreshRec.Code, http.StatusUnauthorized)
+	}
+}

--- a/internal/api/auth/handler.go
+++ b/internal/api/auth/handler.go
@@ -1,0 +1,241 @@
+package auth
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/good-yellow-bee/blazelog/internal/storage"
+)
+
+// Handler handles authentication endpoints.
+type Handler struct {
+	storage        storage.Storage
+	jwtService     *JWTService
+	tokenService   *TokenService
+	lockoutTracker *LockoutTracker
+}
+
+// NewHandler creates a new auth handler.
+func NewHandler(store storage.Storage, jwt *JWTService, lockout *LockoutTracker, refreshTTL time.Duration) *Handler {
+	return &Handler{
+		storage:        store,
+		jwtService:     jwt,
+		tokenService:   NewTokenService(store, refreshTTL),
+		lockoutTracker: lockout,
+	}
+}
+
+// Response helpers (local to avoid import cycle with api package)
+
+type errorResponse struct {
+	Error errorBody `json:"error"`
+}
+
+type errorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type dataResponse struct {
+	Data any `json:"data"`
+}
+
+func jsonError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(errorResponse{Error: errorBody{Code: code, Message: message}})
+}
+
+func jsonOK(w http.ResponseWriter, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(dataResponse{Data: data})
+}
+
+func jsonNoContent(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// LoginResponse is returned on successful login.
+type LoginResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+}
+
+// Error codes and messages
+const (
+	errCodeBadRequest    = "BAD_REQUEST"
+	errCodeUnauthorized  = "UNAUTHORIZED"
+	errCodeAccountLocked = "ACCOUNT_LOCKED"
+	errCodeInternalError = "INTERNAL_ERROR"
+)
+
+// LoginRequest is the request body for login.
+type LoginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// RefreshRequest is the request body for token refresh.
+type RefreshRequest struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
+// LogoutRequest is the request body for logout.
+type LogoutRequest struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
+// Login handles user login.
+func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
+	var req LoginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Username == "" || req.Password == "" {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "username and password required")
+		return
+	}
+
+	// Check lockout
+	if h.lockoutTracker.IsLocked(req.Username) {
+		remaining := h.lockoutTracker.RemainingLockoutTime(req.Username)
+		log.Printf("login blocked: account %s locked for %v", req.Username, remaining)
+		jsonError(w, http.StatusTooManyRequests, errCodeAccountLocked, "account temporarily locked due to too many failed attempts")
+		return
+	}
+
+	// Get user
+	ctx := r.Context()
+	user, err := h.storage.Users().GetByUsername(ctx, req.Username)
+	if err != nil {
+		log.Printf("login error: get user: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+	if user == nil {
+		h.lockoutTracker.RecordFailure(req.Username)
+		log.Printf("login failed: user %s not found", req.Username)
+		jsonError(w, http.StatusUnauthorized, errCodeUnauthorized, "invalid credentials")
+		return
+	}
+
+	// Verify password
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)); err != nil {
+		h.lockoutTracker.RecordFailure(req.Username)
+		log.Printf("login failed: invalid password for user %s", req.Username)
+		jsonError(w, http.StatusUnauthorized, errCodeUnauthorized, "invalid credentials")
+		return
+	}
+
+	// Clear lockout on success
+	h.lockoutTracker.ClearFailures(req.Username)
+
+	// Generate access token
+	accessToken, err := h.jwtService.GenerateToken(user)
+	if err != nil {
+		log.Printf("login error: generate access token: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+
+	// Generate refresh token
+	refreshToken, err := h.tokenService.CreateRefreshToken(ctx, user.ID)
+	if err != nil {
+		log.Printf("login error: generate refresh token: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+
+	log.Printf("login success: user %s", req.Username)
+
+	jsonOK(w, &LoginResponse{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		ExpiresIn:    h.jwtService.TTLSeconds(),
+		TokenType:    "Bearer",
+	})
+}
+
+// Refresh handles token refresh.
+func (h *Handler) Refresh(w http.ResponseWriter, r *http.Request) {
+	var req RefreshRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "invalid request body")
+		return
+	}
+
+	if req.RefreshToken == "" {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "refresh_token required")
+		return
+	}
+
+	ctx := r.Context()
+
+	// Validate refresh token and get user
+	user, err := h.tokenService.ValidateRefreshToken(ctx, req.RefreshToken)
+	if err != nil {
+		log.Printf("refresh failed: %v", err)
+		jsonError(w, http.StatusUnauthorized, errCodeUnauthorized, "invalid or expired token")
+		return
+	}
+
+	// Generate new access token
+	accessToken, err := h.jwtService.GenerateToken(user)
+	if err != nil {
+		log.Printf("refresh error: generate access token: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+
+	// Rotate refresh token (revoke old, create new)
+	newRefreshToken, err := h.tokenService.RotateRefreshToken(ctx, req.RefreshToken, user.ID)
+	if err != nil {
+		log.Printf("refresh error: rotate refresh token: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+
+	log.Printf("token refresh success: user %s", user.Username)
+
+	jsonOK(w, &LoginResponse{
+		AccessToken:  accessToken,
+		RefreshToken: newRefreshToken,
+		ExpiresIn:    h.jwtService.TTLSeconds(),
+		TokenType:    "Bearer",
+	})
+}
+
+// Logout handles user logout.
+func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
+	var req LogoutRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "invalid request body")
+		return
+	}
+
+	if req.RefreshToken == "" {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "refresh_token required")
+		return
+	}
+
+	ctx := r.Context()
+
+	// Revoke the refresh token
+	if err := h.tokenService.RevokeRefreshToken(ctx, req.RefreshToken); err != nil {
+		log.Printf("logout error: revoke token: %v", err)
+		// Don't return error - token might already be revoked
+	}
+
+	log.Printf("logout success")
+
+	jsonNoContent(w)
+}

--- a/internal/api/auth/jwt.go
+++ b/internal/api/auth/jwt.go
@@ -1,0 +1,93 @@
+// Package auth provides authentication and authorization functionality.
+package auth
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+// Claims represents the JWT claims for access tokens.
+type Claims struct {
+	jwt.RegisteredClaims
+	UserID   string      `json:"uid"`
+	Username string      `json:"usr"`
+	Role     models.Role `json:"role"`
+}
+
+// JWTService handles JWT token generation and validation.
+type JWTService struct {
+	secret []byte
+	ttl    time.Duration
+	issuer string
+}
+
+// NewJWTService creates a new JWT service.
+func NewJWTService(secret []byte, ttl time.Duration) *JWTService {
+	return &JWTService{
+		secret: secret,
+		ttl:    ttl,
+		issuer: "blazelog",
+	}
+}
+
+// GenerateToken creates a new JWT access token for the given user.
+func (s *JWTService) GenerateToken(user *models.User) (string, error) {
+	now := time.Now()
+	expiresAt := now.Add(s.ttl)
+
+	claims := &Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    s.issuer,
+			Subject:   user.ID,
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+		},
+		UserID:   user.ID,
+		Username: user.Username,
+		Role:     user.Role,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(s.secret)
+}
+
+// ValidateToken validates a JWT token and returns the claims.
+func (s *JWTService) ValidateToken(tokenString string) (*Claims, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (any, error) {
+		// Validate signing method
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return s.secret, nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("parse token: %w", err)
+	}
+
+	claims, ok := token.Claims.(*Claims)
+	if !ok || !token.Valid {
+		return nil, fmt.Errorf("invalid token claims")
+	}
+
+	// Verify issuer
+	if claims.Issuer != s.issuer {
+		return nil, fmt.Errorf("invalid issuer")
+	}
+
+	return claims, nil
+}
+
+// TTL returns the token time-to-live duration.
+func (s *JWTService) TTL() time.Duration {
+	return s.ttl
+}
+
+// TTLSeconds returns the token TTL in seconds.
+func (s *JWTService) TTLSeconds() int {
+	return int(s.ttl.Seconds())
+}

--- a/internal/api/auth/jwt_test.go
+++ b/internal/api/auth/jwt_test.go
@@ -1,0 +1,130 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+func TestJWTService_GenerateAndValidate(t *testing.T) {
+	secret := []byte("test-secret-key-32-bytes-long!!")
+	ttl := 15 * time.Minute
+	svc := NewJWTService(secret, ttl)
+
+	user := &models.User{
+		ID:       "user-123",
+		Username: "testuser",
+		Role:     models.RoleAdmin,
+	}
+
+	// Generate token
+	token, err := svc.GenerateToken(user)
+	if err != nil {
+		t.Fatalf("GenerateToken failed: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	// Validate token
+	claims, err := svc.ValidateToken(token)
+	if err != nil {
+		t.Fatalf("ValidateToken failed: %v", err)
+	}
+
+	if claims.UserID != user.ID {
+		t.Errorf("UserID = %q, want %q", claims.UserID, user.ID)
+	}
+	if claims.Username != user.Username {
+		t.Errorf("Username = %q, want %q", claims.Username, user.Username)
+	}
+	if claims.Role != user.Role {
+		t.Errorf("Role = %q, want %q", claims.Role, user.Role)
+	}
+}
+
+func TestJWTService_InvalidToken(t *testing.T) {
+	secret := []byte("test-secret-key-32-bytes-long!!")
+	ttl := 15 * time.Minute
+	svc := NewJWTService(secret, ttl)
+
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{"empty", ""},
+		{"garbage", "not-a-jwt-token"},
+		{"wrong-segments", "a.b"},
+		{"invalid-signature", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiJ0ZXN0In0.invalid"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.ValidateToken(tc.token)
+			if err == nil {
+				t.Error("expected error for invalid token")
+			}
+		})
+	}
+}
+
+func TestJWTService_DifferentSecret(t *testing.T) {
+	ttl := 15 * time.Minute
+	svc1 := NewJWTService([]byte("secret-one-32-bytes-long!!!!!!!"), ttl)
+	svc2 := NewJWTService([]byte("secret-two-32-bytes-long!!!!!!!"), ttl)
+
+	user := &models.User{
+		ID:       "user-123",
+		Username: "testuser",
+		Role:     models.RoleViewer,
+	}
+
+	token, err := svc1.GenerateToken(user)
+	if err != nil {
+		t.Fatalf("GenerateToken failed: %v", err)
+	}
+
+	// Token signed with svc1 should fail validation with svc2
+	_, err = svc2.ValidateToken(token)
+	if err == nil {
+		t.Error("expected error validating token with different secret")
+	}
+}
+
+func TestJWTService_ExpiredToken(t *testing.T) {
+	secret := []byte("test-secret-key-32-bytes-long!!")
+	ttl := 1 * time.Millisecond // Very short TTL
+	svc := NewJWTService(secret, ttl)
+
+	user := &models.User{
+		ID:       "user-123",
+		Username: "testuser",
+		Role:     models.RoleOperator,
+	}
+
+	token, err := svc.GenerateToken(user)
+	if err != nil {
+		t.Fatalf("GenerateToken failed: %v", err)
+	}
+
+	// Wait for expiration
+	time.Sleep(10 * time.Millisecond)
+
+	_, err = svc.ValidateToken(token)
+	if err == nil {
+		t.Error("expected error for expired token")
+	}
+}
+
+func TestJWTService_TTLSeconds(t *testing.T) {
+	secret := []byte("test-secret-key-32-bytes-long!!")
+	ttl := 15 * time.Minute
+	svc := NewJWTService(secret, ttl)
+
+	got := svc.TTLSeconds()
+	want := 900 // 15 * 60
+	if got != want {
+		t.Errorf("TTLSeconds() = %d, want %d", got, want)
+	}
+}

--- a/internal/api/auth/lockout.go
+++ b/internal/api/auth/lockout.go
@@ -1,0 +1,149 @@
+package auth
+
+import (
+	"sync"
+	"time"
+)
+
+// lockoutEntry tracks failed login attempts for an account.
+type lockoutEntry struct {
+	failures  int
+	lockedAt  time.Time
+	expiresAt time.Time
+}
+
+// LockoutTracker tracks failed login attempts and account lockouts.
+type LockoutTracker struct {
+	mu              sync.RWMutex
+	entries         map[string]*lockoutEntry // keyed by username or IP
+	threshold       int                      // number of failures before lockout
+	lockoutDuration time.Duration
+}
+
+// NewLockoutTracker creates a new lockout tracker.
+func NewLockoutTracker(threshold int, duration time.Duration) *LockoutTracker {
+	tracker := &LockoutTracker{
+		entries:         make(map[string]*lockoutEntry),
+		threshold:       threshold,
+		lockoutDuration: duration,
+	}
+
+	// Start cleanup goroutine
+	go tracker.cleanupLoop()
+
+	return tracker
+}
+
+// RecordFailure records a failed login attempt.
+// Returns true if the account is now locked.
+func (t *LockoutTracker) RecordFailure(key string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	entry, exists := t.entries[key]
+	if !exists {
+		entry = &lockoutEntry{}
+		t.entries[key] = entry
+	}
+
+	// If already locked and not expired, don't increment
+	if entry.lockedAt.After(time.Time{}) && time.Now().Before(entry.expiresAt) {
+		return true
+	}
+
+	// If lockout expired, reset
+	if entry.lockedAt.After(time.Time{}) && time.Now().After(entry.expiresAt) {
+		entry.failures = 0
+		entry.lockedAt = time.Time{}
+		entry.expiresAt = time.Time{}
+	}
+
+	entry.failures++
+
+	// Check if we should lock
+	if entry.failures >= t.threshold {
+		now := time.Now()
+		entry.lockedAt = now
+		entry.expiresAt = now.Add(t.lockoutDuration)
+		return true
+	}
+
+	return false
+}
+
+// IsLocked returns true if the account is currently locked.
+func (t *LockoutTracker) IsLocked(key string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	entry, exists := t.entries[key]
+	if !exists {
+		return false
+	}
+
+	// Not locked
+	if entry.lockedAt.IsZero() {
+		return false
+	}
+
+	// Check if lockout expired
+	if time.Now().After(entry.expiresAt) {
+		return false
+	}
+
+	return true
+}
+
+// RemainingLockoutTime returns how long until the lockout expires.
+func (t *LockoutTracker) RemainingLockoutTime(key string) time.Duration {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	entry, exists := t.entries[key]
+	if !exists {
+		return 0
+	}
+
+	if entry.lockedAt.IsZero() {
+		return 0
+	}
+
+	remaining := time.Until(entry.expiresAt)
+	if remaining < 0 {
+		return 0
+	}
+
+	return remaining
+}
+
+// ClearFailures clears failed attempts on successful login.
+func (t *LockoutTracker) ClearFailures(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	delete(t.entries, key)
+}
+
+// cleanupLoop periodically removes expired entries.
+func (t *LockoutTracker) cleanupLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		t.cleanup()
+	}
+}
+
+// cleanup removes expired entries.
+func (t *LockoutTracker) cleanup() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := time.Now()
+	for key, entry := range t.entries {
+		// Remove entries with expired lockouts or no failures
+		if entry.failures == 0 || (entry.lockedAt.After(time.Time{}) && now.After(entry.expiresAt)) {
+			delete(t.entries, key)
+		}
+	}
+}

--- a/internal/api/auth/lockout_test.go
+++ b/internal/api/auth/lockout_test.go
@@ -1,0 +1,125 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLockoutTracker_Basic(t *testing.T) {
+	tracker := NewLockoutTracker(3, 100*time.Millisecond)
+	username := "testuser"
+
+	// Initially not locked
+	if tracker.IsLocked(username) {
+		t.Error("user should not be locked initially")
+	}
+
+	// Record failures below threshold
+	tracker.RecordFailure(username)
+	tracker.RecordFailure(username)
+	if tracker.IsLocked(username) {
+		t.Error("user should not be locked after 2 failures (threshold=3)")
+	}
+
+	// Third failure should trigger lockout
+	tracker.RecordFailure(username)
+	if !tracker.IsLocked(username) {
+		t.Error("user should be locked after 3 failures")
+	}
+}
+
+func TestLockoutTracker_LockoutExpires(t *testing.T) {
+	tracker := NewLockoutTracker(2, 50*time.Millisecond)
+	username := "testuser"
+
+	tracker.RecordFailure(username)
+	tracker.RecordFailure(username)
+
+	if !tracker.IsLocked(username) {
+		t.Error("user should be locked")
+	}
+
+	// Wait for lockout to expire
+	time.Sleep(60 * time.Millisecond)
+
+	if tracker.IsLocked(username) {
+		t.Error("lockout should have expired")
+	}
+}
+
+func TestLockoutTracker_ClearFailures(t *testing.T) {
+	tracker := NewLockoutTracker(3, time.Hour)
+	username := "testuser"
+
+	tracker.RecordFailure(username)
+	tracker.RecordFailure(username)
+	tracker.RecordFailure(username)
+
+	if !tracker.IsLocked(username) {
+		t.Error("user should be locked")
+	}
+
+	tracker.ClearFailures(username)
+
+	if tracker.IsLocked(username) {
+		t.Error("user should not be locked after clear")
+	}
+}
+
+func TestLockoutTracker_RemainingTime(t *testing.T) {
+	lockoutDuration := 100 * time.Millisecond
+	tracker := NewLockoutTracker(1, lockoutDuration)
+	username := "testuser"
+
+	// No lockout initially
+	remaining := tracker.RemainingLockoutTime(username)
+	if remaining != 0 {
+		t.Errorf("remaining time should be 0, got %v", remaining)
+	}
+
+	tracker.RecordFailure(username)
+
+	remaining = tracker.RemainingLockoutTime(username)
+	if remaining <= 0 {
+		t.Error("remaining time should be positive after lockout")
+	}
+	if remaining > lockoutDuration {
+		t.Errorf("remaining time %v should not exceed lockout duration %v", remaining, lockoutDuration)
+	}
+}
+
+func TestLockoutTracker_IndependentUsers(t *testing.T) {
+	tracker := NewLockoutTracker(2, time.Hour)
+	user1 := "user1"
+	user2 := "user2"
+
+	tracker.RecordFailure(user1)
+	tracker.RecordFailure(user1)
+
+	if !tracker.IsLocked(user1) {
+		t.Error("user1 should be locked")
+	}
+	if tracker.IsLocked(user2) {
+		t.Error("user2 should not be locked")
+	}
+}
+
+func TestLockoutTracker_FailureCountReset(t *testing.T) {
+	tracker := NewLockoutTracker(2, 30*time.Millisecond)
+	username := "testuser"
+
+	// Record one failure, then clear
+	tracker.RecordFailure(username)
+	tracker.ClearFailures(username)
+
+	// Should need 2 failures again, not 1
+	tracker.RecordFailure(username)
+	if tracker.IsLocked(username) {
+		t.Error("user should not be locked after clear and 1 failure")
+	}
+
+	tracker.RecordFailure(username)
+	if !tracker.IsLocked(username) {
+		t.Error("user should be locked after 2 failures")
+	}
+}

--- a/internal/api/auth/password.go
+++ b/internal/api/auth/password.go
@@ -1,0 +1,88 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"unicode"
+)
+
+// PasswordValidationError contains details about password validation failure.
+type PasswordValidationError struct {
+	Messages []string
+}
+
+func (e *PasswordValidationError) Error() string {
+	return strings.Join(e.Messages, "; ")
+}
+
+// ValidatePassword checks if a password meets complexity requirements.
+// Requirements:
+// - Minimum 12 characters
+// - At least 1 uppercase letter (A-Z)
+// - At least 1 lowercase letter (a-z)
+// - At least 1 digit (0-9)
+// - At least 1 special character
+func ValidatePassword(password string) error {
+	var messages []string
+
+	if len(password) < 12 {
+		messages = append(messages, "password must be at least 12 characters")
+	}
+
+	var (
+		hasUpper   bool
+		hasLower   bool
+		hasDigit   bool
+		hasSpecial bool
+	)
+
+	for _, r := range password {
+		switch {
+		case unicode.IsUpper(r):
+			hasUpper = true
+		case unicode.IsLower(r):
+			hasLower = true
+		case unicode.IsDigit(r):
+			hasDigit = true
+		case isSpecialChar(r):
+			hasSpecial = true
+		}
+	}
+
+	if !hasUpper {
+		messages = append(messages, "password must contain at least 1 uppercase letter")
+	}
+	if !hasLower {
+		messages = append(messages, "password must contain at least 1 lowercase letter")
+	}
+	if !hasDigit {
+		messages = append(messages, "password must contain at least 1 digit")
+	}
+	if !hasSpecial {
+		messages = append(messages, "password must contain at least 1 special character (!@#$%^&*...)")
+	}
+
+	if len(messages) > 0 {
+		return &PasswordValidationError{Messages: messages}
+	}
+
+	return nil
+}
+
+// isSpecialChar returns true if the rune is a special character.
+func isSpecialChar(r rune) bool {
+	specials := "!@#$%^&*()-_=+[]{}|;:',.<>?/`~\"\\"
+	return strings.ContainsRune(specials, r)
+}
+
+// ValidatePasswordOrError returns an error suitable for API responses.
+func ValidatePasswordOrError(password string) error {
+	if err := ValidatePassword(password); err != nil {
+		var validErr *PasswordValidationError
+		if errors.As(err, &validErr) {
+			return errors.New(validErr.Messages[0]) // Return first message for API
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/api/auth/password_test.go
+++ b/internal/api/auth/password_test.go
@@ -1,0 +1,99 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePassword(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+		wantOK   bool
+	}{
+		// Valid passwords
+		{"valid complex", "MyP@ssw0rd123!", true},
+		{"valid minimal", "Abcdefgh123!", true},
+		{"valid special chars", "Test123!@#$%^", true},
+
+		// Too short
+		{"too short", "Ab1!", false},
+		{"exactly 11", "Abcdefgh12!", false},
+
+		// Missing uppercase
+		{"no uppercase", "abcdefgh123!", false},
+
+		// Missing lowercase
+		{"no lowercase", "ABCDEFGH123!", false},
+
+		// Missing digit
+		{"no digit", "Abcdefghijk!", false},
+
+		// Missing special
+		{"no special", "Abcdefgh1234", false},
+
+		// Edge cases
+		{"empty", "", false},
+		{"spaces only", "            ", false},
+		{"unicode", "Abcdefgh123!\u00E9", true}, // unicode letter counts as lowercase
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePassword(tc.password)
+			got := err == nil
+			if got != tc.wantOK {
+				t.Errorf("ValidatePassword(%q) error=%v, want valid=%v", tc.password, err, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestValidatePasswordOrError(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+		wantErr  bool
+	}{
+		{"valid", "MyP@ssw0rd123!", false},
+		{"too short", "Ab1!", true},
+		{"no uppercase", "abcdefgh123!", true},
+		{"no lowercase", "ABCDEFGH123!", true},
+		{"no digit", "Abcdefghijk!", true},
+		{"no special", "Abcdefgh1234", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePasswordOrError(tc.password)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidatePasswordOrError(%q) error = %v, wantErr %v", tc.password, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidatePasswordOrError_Messages(t *testing.T) {
+	tests := []struct {
+		password    string
+		wantContain string
+	}{
+		{"short", "at least 12"},
+		{"abcdefgh123!", "uppercase"},
+		{"ABCDEFGH123!", "lowercase"},
+		{"Abcdefghijk!", "digit"},
+		{"Abcdefgh1234", "special"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.wantContain, func(t *testing.T) {
+			err := ValidatePasswordOrError(tc.password)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.wantContain) {
+				t.Errorf("error %q should contain %q", err.Error(), tc.wantContain)
+			}
+		})
+	}
+}

--- a/internal/api/auth/tokens.go
+++ b/internal/api/auth/tokens.go
@@ -1,0 +1,100 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+	"github.com/good-yellow-bee/blazelog/internal/storage"
+)
+
+// TokenService handles refresh token operations.
+type TokenService struct {
+	storage storage.Storage
+	ttl     time.Duration
+}
+
+// NewTokenService creates a new token service.
+func NewTokenService(store storage.Storage, ttl time.Duration) *TokenService {
+	return &TokenService{
+		storage: store,
+		ttl:     ttl,
+	}
+}
+
+// CreateRefreshToken creates and stores a new refresh token for the user.
+// Returns the plaintext token to send to the client.
+func (s *TokenService) CreateRefreshToken(ctx context.Context, userID string) (string, error) {
+	token, plainToken, err := models.NewRefreshToken(userID, s.ttl)
+	if err != nil {
+		return "", fmt.Errorf("generate refresh token: %w", err)
+	}
+
+	if err := s.storage.Tokens().Create(ctx, token); err != nil {
+		return "", fmt.Errorf("store refresh token: %w", err)
+	}
+
+	return plainToken, nil
+}
+
+// ValidateRefreshToken validates a refresh token and returns the associated user.
+func (s *TokenService) ValidateRefreshToken(ctx context.Context, plainToken string) (*models.User, error) {
+	tokenHash := models.HashToken(plainToken)
+
+	token, err := s.storage.Tokens().GetByTokenHash(ctx, tokenHash)
+	if err != nil {
+		return nil, fmt.Errorf("lookup refresh token: %w", err)
+	}
+	if token == nil {
+		return nil, fmt.Errorf("token not found")
+	}
+
+	if !token.IsValid() {
+		return nil, fmt.Errorf("token expired or revoked")
+	}
+
+	// Get user
+	user, err := s.storage.Users().GetByID(ctx, token.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("get user: %w", err)
+	}
+	if user == nil {
+		return nil, fmt.Errorf("user not found")
+	}
+
+	return user, nil
+}
+
+// RevokeRefreshToken revokes a refresh token.
+func (s *TokenService) RevokeRefreshToken(ctx context.Context, plainToken string) error {
+	tokenHash := models.HashToken(plainToken)
+	return s.storage.Tokens().RevokeByTokenHash(ctx, tokenHash)
+}
+
+// RevokeAllUserTokens revokes all refresh tokens for a user.
+func (s *TokenService) RevokeAllUserTokens(ctx context.Context, userID string) error {
+	return s.storage.Tokens().RevokeAllForUser(ctx, userID)
+}
+
+// RotateRefreshToken revokes the old token and creates a new one.
+// Returns the new plaintext token.
+func (s *TokenService) RotateRefreshToken(ctx context.Context, oldPlainToken string, userID string) (string, error) {
+	// Revoke old token
+	if err := s.RevokeRefreshToken(ctx, oldPlainToken); err != nil {
+		// Log but don't fail - we still want to issue new token
+	}
+
+	// Create new token
+	return s.CreateRefreshToken(ctx, userID)
+}
+
+// CleanupExpiredTokens removes expired tokens from storage.
+func (s *TokenService) CleanupExpiredTokens(ctx context.Context) (int64, error) {
+	return s.storage.Tokens().DeleteExpired(ctx)
+}
+
+// TTL returns the refresh token time-to-live.
+func (s *TokenService) TTL() time.Duration {
+	return s.ttl
+}

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,0 +1,114 @@
+package api
+
+import "net/http"
+
+// Error represents an API error response.
+type Error struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Status  int    `json:"-"`
+}
+
+func (e *Error) Error() string {
+	return e.Message
+}
+
+// Common error codes
+const (
+	ErrCodeUnauthorized     = "UNAUTHORIZED"
+	ErrCodeForbidden        = "FORBIDDEN"
+	ErrCodeNotFound         = "NOT_FOUND"
+	ErrCodeBadRequest       = "BAD_REQUEST"
+	ErrCodeConflict         = "CONFLICT"
+	ErrCodeInternalError    = "INTERNAL_ERROR"
+	ErrCodeRateLimited      = "RATE_LIMITED"
+	ErrCodeAccountLocked    = "ACCOUNT_LOCKED"
+	ErrCodeValidationFailed = "VALIDATION_FAILED"
+)
+
+// Standard errors
+var (
+	ErrUnauthorized = &Error{
+		Code:    ErrCodeUnauthorized,
+		Message: "Invalid credentials",
+		Status:  http.StatusUnauthorized,
+	}
+
+	ErrInvalidToken = &Error{
+		Code:    ErrCodeUnauthorized,
+		Message: "Invalid or expired token",
+		Status:  http.StatusUnauthorized,
+	}
+
+	ErrForbidden = &Error{
+		Code:    ErrCodeForbidden,
+		Message: "Access denied",
+		Status:  http.StatusForbidden,
+	}
+
+	ErrNotFound = &Error{
+		Code:    ErrCodeNotFound,
+		Message: "Resource not found",
+		Status:  http.StatusNotFound,
+	}
+
+	ErrUserNotFound = &Error{
+		Code:    ErrCodeNotFound,
+		Message: "User not found",
+		Status:  http.StatusNotFound,
+	}
+
+	ErrInternalServer = &Error{
+		Code:    ErrCodeInternalError,
+		Message: "Internal server error",
+		Status:  http.StatusInternalServerError,
+	}
+
+	ErrRateLimited = &Error{
+		Code:    ErrCodeRateLimited,
+		Message: "Too many requests",
+		Status:  http.StatusTooManyRequests,
+	}
+
+	ErrAccountLocked = &Error{
+		Code:    ErrCodeAccountLocked,
+		Message: "Account temporarily locked due to too many failed attempts",
+		Status:  http.StatusTooManyRequests,
+	}
+)
+
+// NewBadRequest creates a bad request error with custom message.
+func NewBadRequest(message string) *Error {
+	return &Error{
+		Code:    ErrCodeBadRequest,
+		Message: message,
+		Status:  http.StatusBadRequest,
+	}
+}
+
+// NewValidationError creates a validation error with custom message.
+func NewValidationError(message string) *Error {
+	return &Error{
+		Code:    ErrCodeValidationFailed,
+		Message: message,
+		Status:  http.StatusBadRequest,
+	}
+}
+
+// NewConflict creates a conflict error with custom message.
+func NewConflict(message string) *Error {
+	return &Error{
+		Code:    ErrCodeConflict,
+		Message: message,
+		Status:  http.StatusConflict,
+	}
+}
+
+// NewNotFound creates a not found error with custom message.
+func NewNotFound(message string) *Error {
+	return &Error{
+		Code:    ErrCodeNotFound,
+		Message: message,
+		Status:  http.StatusNotFound,
+	}
+}

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -1,0 +1,116 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/good-yellow-bee/blazelog/internal/api/auth"
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+// Context keys for storing user information.
+type contextKey string
+
+const (
+	userIDKey   contextKey = "user_id"
+	usernameKey contextKey = "username"
+	roleKey     contextKey = "role"
+	claimsKey   contextKey = "claims"
+)
+
+// jsonUnauthorized writes an unauthorized error response.
+func jsonUnauthorized(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{
+			"code":    "UNAUTHORIZED",
+			"message": "invalid or expired token",
+		},
+	})
+}
+
+// jsonForbidden writes a forbidden error response.
+func jsonForbidden(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{
+			"code":    "FORBIDDEN",
+			"message": "access denied",
+		},
+	})
+}
+
+// JWTAuth returns middleware that validates JWT tokens.
+func JWTAuth(jwtService *auth.JWTService) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Get token from Authorization header
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" {
+				jsonUnauthorized(w)
+				return
+			}
+
+			// Parse Bearer token
+			parts := strings.SplitN(authHeader, " ", 2)
+			if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+				jsonUnauthorized(w)
+				return
+			}
+
+			tokenString := parts[1]
+
+			// Validate token
+			claims, err := jwtService.ValidateToken(tokenString)
+			if err != nil {
+				jsonUnauthorized(w)
+				return
+			}
+
+			// Add claims to context
+			ctx := r.Context()
+			ctx = context.WithValue(ctx, userIDKey, claims.UserID)
+			ctx = context.WithValue(ctx, usernameKey, claims.Username)
+			ctx = context.WithValue(ctx, roleKey, claims.Role)
+			ctx = context.WithValue(ctx, claimsKey, claims)
+
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// GetUserID returns the user ID from context.
+func GetUserID(ctx context.Context) string {
+	if v := ctx.Value(userIDKey); v != nil {
+		return v.(string)
+	}
+	return ""
+}
+
+// GetUsername returns the username from context.
+func GetUsername(ctx context.Context) string {
+	if v := ctx.Value(usernameKey); v != nil {
+		return v.(string)
+	}
+	return ""
+}
+
+// GetRole returns the user role from context.
+func GetRole(ctx context.Context) models.Role {
+	if v := ctx.Value(roleKey); v != nil {
+		return v.(models.Role)
+	}
+	return ""
+}
+
+// GetClaims returns the JWT claims from context.
+func GetClaims(ctx context.Context) *auth.Claims {
+	if v := ctx.Value(claimsKey); v != nil {
+		return v.(*auth.Claims)
+	}
+	return nil
+}

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -1,0 +1,165 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/api/auth"
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+func TestJWTAuth_ValidToken(t *testing.T) {
+	secret := []byte("test-secret-key-32-bytes-long!!")
+	jwtService := auth.NewJWTService(secret, 15*time.Minute)
+
+	user := &models.User{
+		ID:       "user-123",
+		Username: "testuser",
+		Role:     models.RoleAdmin,
+	}
+
+	token, err := jwtService.GenerateToken(user)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	// Create handler that checks context values
+	var gotUserID, gotUsername string
+	var gotRole models.Role
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserID = GetUserID(r.Context())
+		gotUsername = GetUsername(r.Context())
+		gotRole = GetRole(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Wrap with middleware
+	wrapped := JWTAuth(jwtService)(handler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if gotUserID != user.ID {
+		t.Errorf("UserID = %q, want %q", gotUserID, user.ID)
+	}
+	if gotUsername != user.Username {
+		t.Errorf("Username = %q, want %q", gotUsername, user.Username)
+	}
+	if gotRole != user.Role {
+		t.Errorf("Role = %q, want %q", gotRole, user.Role)
+	}
+}
+
+func TestJWTAuth_MissingToken(t *testing.T) {
+	secret := []byte("test-secret-key-32-bytes-long!!")
+	jwtService := auth.NewJWTService(secret, 15*time.Minute)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	})
+
+	wrapped := JWTAuth(jwtService)(handler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestJWTAuth_InvalidToken(t *testing.T) {
+	secret := []byte("test-secret-key-32-bytes-long!!")
+	jwtService := auth.NewJWTService(secret, 15*time.Minute)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	})
+
+	wrapped := JWTAuth(jwtService)(handler)
+
+	tests := []struct {
+		name   string
+		header string
+	}{
+		{"invalid format", "NotBearer token"},
+		{"invalid token", "Bearer invalid-token"},
+		{"empty bearer", "Bearer "},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.Header.Set("Authorization", tc.header)
+			rec := httptest.NewRecorder()
+
+			wrapped.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+			}
+		})
+	}
+}
+
+func TestJWTAuth_ExpiredToken(t *testing.T) {
+	secret := []byte("test-secret-key-32-bytes-long!!")
+	jwtService := auth.NewJWTService(secret, 1*time.Millisecond)
+
+	user := &models.User{
+		ID:       "user-123",
+		Username: "testuser",
+		Role:     models.RoleViewer,
+	}
+
+	token, err := jwtService.GenerateToken(user)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	})
+
+	wrapped := JWTAuth(jwtService)(handler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestContextHelpers_Empty(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test", nil)
+	ctx := req.Context()
+
+	if got := GetUserID(ctx); got != "" {
+		t.Errorf("GetUserID() = %q, want empty", got)
+	}
+	if got := GetUsername(ctx); got != "" {
+		t.Errorf("GetUsername() = %q, want empty", got)
+	}
+	if got := GetRole(ctx); got != "" {
+		t.Errorf("GetRole() = %q, want empty", got)
+	}
+	if got := GetClaims(ctx); got != nil {
+		t.Errorf("GetClaims() = %v, want nil", got)
+	}
+}

--- a/internal/api/middleware/headers.go
+++ b/internal/api/middleware/headers.go
@@ -1,0 +1,42 @@
+package middleware
+
+import "net/http"
+
+// SecurityHeaders adds security-related HTTP headers to responses.
+func SecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Prevent MIME type sniffing
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+
+		// Prevent clickjacking
+		w.Header().Set("X-Frame-Options", "DENY")
+
+		// XSS protection (legacy, but still useful)
+		w.Header().Set("X-XSS-Protection", "1; mode=block")
+
+		// Referrer policy
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+
+		// Content Security Policy
+		w.Header().Set("Content-Security-Policy", "default-src 'self'")
+
+		// Permissions policy (modern replacement for Feature-Policy)
+		w.Header().Set("Permissions-Policy", "geolocation=(), microphone=(), camera=()")
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Recoverer recovers from panics and returns a 500 error.
+func Recoverer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(`{"error":{"code":"INTERNAL_ERROR","message":"Internal server error"}}`))
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -1,0 +1,60 @@
+// Package middleware provides HTTP middleware for the API.
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// responseWriter wraps http.ResponseWriter to capture status code.
+type responseWriter struct {
+	http.ResponseWriter
+	status int
+	size   int
+}
+
+func (rw *responseWriter) WriteHeader(status int) {
+	rw.status = status
+	rw.ResponseWriter.WriteHeader(status)
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	n, err := rw.ResponseWriter.Write(b)
+	rw.size += n
+	return n, err
+}
+
+// RequestLogger returns a middleware that logs HTTP requests.
+func RequestLogger(verbose bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			requestID := uuid.New().String()[:8]
+
+			// Add request ID to response headers
+			w.Header().Set("X-Request-ID", requestID)
+
+			// Wrap response writer
+			wrapped := &responseWriter{ResponseWriter: w, status: http.StatusOK}
+
+			// Process request
+			next.ServeHTTP(wrapped, r)
+
+			// Log request
+			duration := time.Since(start)
+			if verbose || wrapped.status >= 400 {
+				log.Printf("[%s] %s %s %d %d %v",
+					requestID,
+					r.Method,
+					r.URL.Path,
+					wrapped.status,
+					wrapped.size,
+					duration,
+				)
+			}
+		})
+	}
+}

--- a/internal/api/middleware/ratelimit.go
+++ b/internal/api/middleware/ratelimit.go
@@ -1,0 +1,169 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// RateLimiter implements a sliding window rate limiter.
+type RateLimiter struct {
+	mu       sync.Mutex
+	requests map[string][]time.Time
+	limit    int           // max requests per window
+	window   time.Duration // window duration
+}
+
+// NewRateLimiter creates a new rate limiter.
+// limit is requests per minute.
+func NewRateLimiter(limit int) *RateLimiter {
+	rl := &RateLimiter{
+		requests: make(map[string][]time.Time),
+		limit:    limit,
+		window:   time.Minute,
+	}
+
+	// Start cleanup goroutine
+	go rl.cleanupLoop()
+
+	return rl
+}
+
+// Allow checks if a request is allowed for the given key.
+func (rl *RateLimiter) Allow(key string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	windowStart := now.Add(-rl.window)
+
+	// Get requests for this key
+	requests := rl.requests[key]
+
+	// Filter to only requests within the window
+	var validRequests []time.Time
+	for _, t := range requests {
+		if t.After(windowStart) {
+			validRequests = append(validRequests, t)
+		}
+	}
+
+	// Check if under limit
+	if len(validRequests) >= rl.limit {
+		rl.requests[key] = validRequests
+		return false
+	}
+
+	// Add current request
+	validRequests = append(validRequests, now)
+	rl.requests[key] = validRequests
+
+	return true
+}
+
+// cleanupLoop periodically removes old entries.
+func (rl *RateLimiter) cleanupLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		rl.cleanup()
+	}
+}
+
+// cleanup removes old entries.
+func (rl *RateLimiter) cleanup() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	windowStart := now.Add(-rl.window)
+
+	for key, requests := range rl.requests {
+		var validRequests []time.Time
+		for _, t := range requests {
+			if t.After(windowStart) {
+				validRequests = append(validRequests, t)
+			}
+		}
+		if len(validRequests) == 0 {
+			delete(rl.requests, key)
+		} else {
+			rl.requests[key] = validRequests
+		}
+	}
+}
+
+// jsonRateLimited writes a rate limited error response.
+func jsonRateLimited(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusTooManyRequests)
+	json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{
+			"code":    "RATE_LIMITED",
+			"message": "too many requests",
+		},
+	})
+}
+
+// RateLimitByIP returns middleware that rate limits by client IP.
+func RateLimitByIP(limiter *RateLimiter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := getClientIP(r)
+
+			if !limiter.Allow(ip) {
+				jsonRateLimited(w)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RateLimitByUser returns middleware that rate limits by authenticated user.
+func RateLimitByUser(limiter *RateLimiter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			userID := GetUserID(r.Context())
+			if userID == "" {
+				// Fall back to IP if no user
+				userID = getClientIP(r)
+			}
+
+			if !limiter.Allow(userID) {
+				jsonRateLimited(w)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// getClientIP extracts the client IP from the request.
+func getClientIP(r *http.Request) string {
+	// Check X-Forwarded-For header (for proxies)
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// Take the first IP
+		if ip, _, err := net.SplitHostPort(xff); err == nil {
+			return ip
+		}
+		return xff
+	}
+
+	// Check X-Real-IP header
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return xri
+	}
+
+	// Fall back to RemoteAddr
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}

--- a/internal/api/middleware/rbac.go
+++ b/internal/api/middleware/rbac.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+// RequireRole returns middleware that requires specific roles.
+func RequireRole(allowedRoles ...models.Role) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			userRole := GetRole(r.Context())
+			if userRole == "" {
+				jsonForbidden(w)
+				return
+			}
+
+			// Check if user has any of the allowed roles
+			for _, role := range allowedRoles {
+				if userRole == role {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			// Admin always has access
+			if userRole == models.RoleAdmin {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			jsonForbidden(w)
+		})
+	}
+}
+
+// RequireAdmin is shorthand for RequireRole(RoleAdmin).
+func RequireAdmin(next http.Handler) http.Handler {
+	return RequireRole(models.RoleAdmin)(next)
+}
+
+// RequireOperator is shorthand for RequireRole(RoleOperator, RoleAdmin).
+func RequireOperator(next http.Handler) http.Handler {
+	return RequireRole(models.RoleOperator, models.RoleAdmin)(next)
+}
+
+// RequireAdminOrSelf allows access if user is admin or accessing their own resource.
+// Expects {id} URL parameter.
+func RequireAdminOrSelf(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID := GetUserID(r.Context())
+		userRole := GetRole(r.Context())
+
+		// Admin has access to everything
+		if userRole == models.RoleAdmin {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Check if accessing own resource
+		resourceID := chi.URLParam(r, "id")
+		if resourceID != "" && resourceID == userID {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		jsonForbidden(w)
+	})
+}
+
+// RequireCanWrite allows access to admin and operator roles.
+func RequireCanWrite(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userRole := GetRole(r.Context())
+
+		if userRole == models.RoleAdmin || userRole == models.RoleOperator {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		jsonForbidden(w)
+	})
+}

--- a/internal/api/middleware/rbac_test.go
+++ b/internal/api/middleware/rbac_test.go
@@ -1,0 +1,193 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+func setAuthContext(r *http.Request, userID string, role models.Role) *http.Request {
+	ctx := r.Context()
+	ctx = context.WithValue(ctx, userIDKey, userID)
+	ctx = context.WithValue(ctx, roleKey, role)
+	return r.WithContext(ctx)
+}
+
+func TestRequireRole_Allowed(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name     string
+		role     models.Role
+		allowed  []models.Role
+		wantCode int
+	}{
+		{"exact match", models.RoleAdmin, []models.Role{models.RoleAdmin}, http.StatusOK},
+		{"one of many", models.RoleOperator, []models.Role{models.RoleAdmin, models.RoleOperator}, http.StatusOK},
+		{"admin bypass", models.RoleAdmin, []models.Role{models.RoleViewer}, http.StatusOK},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := RequireRole(tc.allowed...)(handler)
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			req = setAuthContext(req, "user-123", tc.role)
+			rec := httptest.NewRecorder()
+
+			wrapped.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestRequireRole_Denied(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	})
+
+	tests := []struct {
+		name    string
+		role    models.Role
+		allowed []models.Role
+	}{
+		{"viewer not admin", models.RoleViewer, []models.Role{models.RoleAdmin}},
+		{"operator not admin", models.RoleOperator, []models.Role{models.RoleAdmin}},
+		{"viewer not operator", models.RoleViewer, []models.Role{models.RoleOperator}},
+		{"empty role", "", []models.Role{models.RoleViewer}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := RequireRole(tc.allowed...)(handler)
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			if tc.role != "" {
+				req = setAuthContext(req, "user-123", tc.role)
+			}
+			rec := httptest.NewRecorder()
+
+			wrapped.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+			}
+		})
+	}
+}
+
+func TestRequireAdmin(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		role     models.Role
+		wantCode int
+	}{
+		{models.RoleAdmin, http.StatusOK},
+		{models.RoleOperator, http.StatusForbidden},
+		{models.RoleViewer, http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.role), func(t *testing.T) {
+			wrapped := RequireAdmin(handler)
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			req = setAuthContext(req, "user-123", tc.role)
+			rec := httptest.NewRecorder()
+
+			wrapped.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestRequireAdminOrSelf(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name       string
+		userID     string
+		role       models.Role
+		resourceID string
+		wantCode   int
+	}{
+		{"admin accessing other", "admin-1", models.RoleAdmin, "user-2", http.StatusOK},
+		{"user accessing self", "user-1", models.RoleViewer, "user-1", http.StatusOK},
+		{"operator accessing self", "user-1", models.RoleOperator, "user-1", http.StatusOK},
+		{"viewer accessing other", "user-1", models.RoleViewer, "user-2", http.StatusForbidden},
+		{"operator accessing other", "user-1", models.RoleOperator, "user-2", http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := RequireAdminOrSelf(handler)
+
+			// Use chi router to set URL param
+			router := chi.NewRouter()
+			router.With(func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					r = setAuthContext(r, tc.userID, tc.role)
+					next.ServeHTTP(w, r)
+				})
+			}).Get("/users/{id}", wrapped.ServeHTTP)
+
+			req := httptest.NewRequest("GET", "/users/"+tc.resourceID, nil)
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestRequireCanWrite(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		role     models.Role
+		wantCode int
+	}{
+		{models.RoleAdmin, http.StatusOK},
+		{models.RoleOperator, http.StatusOK},
+		{models.RoleViewer, http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.role), func(t *testing.T) {
+			wrapped := RequireCanWrite(handler)
+
+			req := httptest.NewRequest("POST", "/test", nil)
+			req = setAuthContext(req, "user-123", tc.role)
+			rec := httptest.NewRecorder()
+
+			wrapped.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantCode)
+			}
+		})
+	}
+}

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Response is a standard API response wrapper.
+type Response struct {
+	Data  any    `json:"data,omitempty"`
+	Error *Error `json:"error,omitempty"`
+}
+
+// JSON writes a JSON response with the given status code.
+func JSON(w http.ResponseWriter, status int, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	resp := Response{Data: data}
+	json.NewEncoder(w).Encode(resp)
+}
+
+// JSONError writes a JSON error response.
+func JSONError(w http.ResponseWriter, err *Error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(err.Status)
+
+	resp := Response{Error: err}
+	json.NewEncoder(w).Encode(resp)
+}
+
+// Created writes a 201 Created response.
+func Created(w http.ResponseWriter, data any) {
+	JSON(w, http.StatusCreated, data)
+}
+
+// OK writes a 200 OK response.
+func OK(w http.ResponseWriter, data any) {
+	JSON(w, http.StatusOK, data)
+}
+
+// NoContent writes a 204 No Content response.
+func NoContent(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// LoginResponse is returned on successful login.
+type LoginResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"` // seconds
+	TokenType    string `json:"token_type"`
+}
+
+// UserResponse is a user without sensitive fields.
+type UserResponse struct {
+	ID        string `json:"id"`
+	Username  string `json:"username"`
+	Email     string `json:"email"`
+	Role      string `json:"role"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// PaginatedResponse wraps a list with pagination info.
+type PaginatedResponse struct {
+	Items      any   `json:"items"`
+	Total      int64 `json:"total"`
+	Page       int   `json:"page"`
+	PerPage    int   `json:"per_page"`
+	TotalPages int   `json:"total_pages"`
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/good-yellow-bee/blazelog/internal/api/auth"
+	"github.com/good-yellow-bee/blazelog/internal/api/middleware"
+	"github.com/good-yellow-bee/blazelog/internal/api/users"
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+// setupRouter creates and configures the chi router with all routes.
+func (s *Server) setupRouter() *chi.Mux {
+	r := chi.NewRouter()
+
+	// Create JWT service
+	jwtService := auth.NewJWTService(s.config.JWTSecret, s.config.AccessTokenTTL)
+
+	// Create lockout tracker
+	lockoutTracker := auth.NewLockoutTracker(s.config.LockoutThreshold, s.config.LockoutDuration)
+
+	// Create rate limiters
+	ipLimiter := middleware.NewRateLimiter(s.config.RateLimitPerIP)
+	userLimiter := middleware.NewRateLimiter(s.config.RateLimitPerUser)
+
+	// Global middleware
+	r.Use(middleware.RequestLogger(s.config.Verbose))
+	r.Use(middleware.SecurityHeaders)
+	r.Use(middleware.Recoverer)
+
+	// API v1 routes
+	r.Route("/api/v1", func(r chi.Router) {
+		// Auth routes (mostly public)
+		r.Route("/auth", func(r chi.Router) {
+			authHandler := auth.NewHandler(
+				s.storage,
+				jwtService,
+				lockoutTracker,
+				s.config.RefreshTokenTTL,
+			)
+
+			// Public routes with IP rate limiting
+			r.Group(func(r chi.Router) {
+				r.Use(middleware.RateLimitByIP(ipLimiter))
+				r.Post("/login", authHandler.Login)
+				r.Post("/refresh", authHandler.Refresh)
+			})
+
+			// Protected routes
+			r.Group(func(r chi.Router) {
+				r.Use(middleware.JWTAuth(jwtService))
+				r.Post("/logout", authHandler.Logout)
+			})
+		})
+
+		// User routes (protected)
+		r.Route("/users", func(r chi.Router) {
+			r.Use(middleware.JWTAuth(jwtService))
+			r.Use(middleware.RateLimitByUser(userLimiter))
+
+			userHandler := users.NewHandler(s.storage)
+
+			// Current user endpoints (any authenticated user)
+			r.Get("/me", userHandler.GetCurrentUser)
+			r.Put("/me/password", userHandler.ChangePassword)
+
+			// Admin-only endpoints
+			r.Group(func(r chi.Router) {
+				r.Use(middleware.RequireRole(models.RoleAdmin))
+				r.Get("/", userHandler.List)
+				r.Post("/", userHandler.Create)
+			})
+
+			// Per-user endpoints (admin or self)
+			r.Route("/{id}", func(r chi.Router) {
+				r.Use(middleware.RequireAdminOrSelf)
+				r.Get("/", userHandler.GetByID)
+				r.Put("/", userHandler.Update)
+
+				// Delete is admin-only
+				r.Group(func(r chi.Router) {
+					r.Use(middleware.RequireRole(models.RoleAdmin))
+					r.Delete("/", userHandler.Delete)
+				})
+			})
+		})
+	})
+
+	// Health check (public, no rate limit)
+	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+		OK(w, map[string]string{"status": "ok"})
+	})
+
+	return r
+}

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -1,0 +1,459 @@
+package users
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/good-yellow-bee/blazelog/internal/api/auth"
+	"github.com/good-yellow-bee/blazelog/internal/api/middleware"
+	"github.com/good-yellow-bee/blazelog/internal/models"
+	"github.com/good-yellow-bee/blazelog/internal/storage"
+)
+
+// Response helpers (local to avoid import cycle)
+
+type errorResponse struct {
+	Error errorBody `json:"error"`
+}
+
+type errorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type dataResponse struct {
+	Data any `json:"data"`
+}
+
+// Error codes
+const (
+	errCodeBadRequest       = "BAD_REQUEST"
+	errCodeValidationFailed = "VALIDATION_FAILED"
+	errCodeNotFound         = "NOT_FOUND"
+	errCodeConflict         = "CONFLICT"
+	errCodeForbidden        = "FORBIDDEN"
+	errCodeInternalError    = "INTERNAL_ERROR"
+)
+
+func jsonError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(errorResponse{Error: errorBody{Code: code, Message: message}})
+}
+
+func jsonOK(w http.ResponseWriter, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(dataResponse{Data: data})
+}
+
+func jsonCreated(w http.ResponseWriter, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(dataResponse{Data: data})
+}
+
+func jsonNoContent(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// UserResponse is a user without sensitive fields.
+type UserResponse struct {
+	ID        string `json:"id"`
+	Username  string `json:"username"`
+	Email     string `json:"email"`
+	Role      string `json:"role"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// Handler handles user management endpoints.
+type Handler struct {
+	storage storage.Storage
+}
+
+// NewHandler creates a new user handler.
+func NewHandler(store storage.Storage) *Handler {
+	return &Handler{storage: store}
+}
+
+// CreateRequest is the request body for creating a user.
+type CreateRequest struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+	Role     string `json:"role"`
+}
+
+// UpdateRequest is the request body for updating a user.
+type UpdateRequest struct {
+	Email string `json:"email,omitempty"`
+	Role  string `json:"role,omitempty"`
+}
+
+// ChangePasswordRequest is the request body for changing password.
+type ChangePasswordRequest struct {
+	CurrentPassword string `json:"current_password"`
+	NewPassword     string `json:"new_password"`
+}
+
+// List returns all users (admin only).
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	users, err := h.storage.Users().List(ctx)
+	if err != nil {
+		log.Printf("list users error: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+
+	// Convert to response format
+	resp := make([]*UserResponse, len(users))
+	for i, u := range users {
+		resp[i] = userToResponse(u)
+	}
+
+	jsonOK(w, resp)
+}
+
+// Create creates a new user (admin only).
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	var req CreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "invalid request body")
+		return
+	}
+
+	// Validate fields
+	if err := ValidateUsername(req.Username); err != nil {
+		jsonError(w, http.StatusBadRequest, errCodeValidationFailed, err.Error())
+		return
+	}
+	if err := ValidateEmail(req.Email); err != nil {
+		jsonError(w, http.StatusBadRequest, errCodeValidationFailed, err.Error())
+		return
+	}
+	if err := auth.ValidatePasswordOrError(req.Password); err != nil {
+		jsonError(w, http.StatusBadRequest, errCodeValidationFailed, err.Error())
+		return
+	}
+
+	role, err := ValidateRole(req.Role)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, errCodeValidationFailed, err.Error())
+		return
+	}
+
+	ctx := r.Context()
+
+	// Check username uniqueness
+	existing, err := h.storage.Users().GetByUsername(ctx, req.Username)
+	if err != nil {
+		log.Printf("create user error: check username: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+	if existing != nil {
+		jsonError(w, http.StatusConflict, errCodeConflict, "username already exists")
+		return
+	}
+
+	// Check email uniqueness
+	existing, err = h.storage.Users().GetByEmail(ctx, req.Email)
+	if err != nil {
+		log.Printf("create user error: check email: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+	if existing != nil {
+		jsonError(w, http.StatusConflict, errCodeConflict, "email already exists")
+		return
+	}
+
+	// Hash password
+	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		log.Printf("create user error: hash password: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+
+	// Create user
+	now := time.Now()
+	user := &models.User{
+		ID:           uuid.New().String(),
+		Username:     strings.TrimSpace(req.Username),
+		Email:        strings.TrimSpace(req.Email),
+		PasswordHash: string(hash),
+		Role:         role,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	if err := h.storage.Users().Create(ctx, user); err != nil {
+		log.Printf("create user error: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+
+	log.Printf("user created: %s (%s)", user.Username, user.ID)
+
+	jsonCreated(w, userToResponse(user))
+}
+
+// GetByID returns a user by ID (admin or self).
+func (h *Handler) GetByID(w http.ResponseWriter, r *http.Request) {
+	userID := chi.URLParam(r, "id")
+	if userID == "" {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "user id required")
+		return
+	}
+
+	ctx := r.Context()
+
+	user, err := h.storage.Users().GetByID(ctx, userID)
+	if err != nil {
+		log.Printf("get user error: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+	if user == nil {
+		jsonError(w, http.StatusNotFound, errCodeNotFound, "user not found")
+		return
+	}
+
+	jsonOK(w, userToResponse(user))
+}
+
+// Update updates a user (admin or self, role change admin only).
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	userID := chi.URLParam(r, "id")
+	if userID == "" {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "user id required")
+		return
+	}
+
+	var req UpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "invalid request body")
+		return
+	}
+
+	ctx := r.Context()
+	currentUserRole := middleware.GetRole(ctx)
+	currentUserID := middleware.GetUserID(ctx)
+
+	// Get existing user
+	user, err := h.storage.Users().GetByID(ctx, userID)
+	if err != nil {
+		log.Printf("update user error: get user: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+	if user == nil {
+		jsonError(w, http.StatusNotFound, errCodeNotFound, "user not found")
+		return
+	}
+
+	// Update email if provided
+	if req.Email != "" {
+		if err := ValidateEmail(req.Email); err != nil {
+			jsonError(w, http.StatusBadRequest, errCodeValidationFailed, err.Error())
+			return
+		}
+
+		// Check email uniqueness
+		existing, err := h.storage.Users().GetByEmail(ctx, req.Email)
+		if err != nil {
+			log.Printf("update user error: check email: %v", err)
+			jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+			return
+		}
+		if existing != nil && existing.ID != userID {
+			jsonError(w, http.StatusConflict, errCodeConflict, "email already exists")
+			return
+		}
+
+		user.Email = strings.TrimSpace(req.Email)
+	}
+
+	// Update role if provided (admin only)
+	if req.Role != "" {
+		// Only admin can change roles
+		if currentUserRole != models.RoleAdmin {
+			jsonError(w, http.StatusForbidden, errCodeForbidden, "access denied")
+			return
+		}
+
+		// Prevent admin from demoting themselves
+		if userID == currentUserID && req.Role != "admin" {
+			jsonError(w, http.StatusBadRequest, errCodeBadRequest, "cannot change own role")
+			return
+		}
+
+		role, err := ValidateRole(req.Role)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, errCodeValidationFailed, err.Error())
+			return
+		}
+		user.Role = role
+	}
+
+	user.UpdatedAt = time.Now()
+
+	if err := h.storage.Users().Update(ctx, user); err != nil {
+		log.Printf("update user error: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+
+	log.Printf("user updated: %s (%s)", user.Username, user.ID)
+
+	jsonOK(w, userToResponse(user))
+}
+
+// Delete deletes a user (admin only).
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	userID := chi.URLParam(r, "id")
+	if userID == "" {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "user id required")
+		return
+	}
+
+	ctx := r.Context()
+	currentUserID := middleware.GetUserID(ctx)
+
+	// Prevent self-deletion
+	if userID == currentUserID {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "cannot delete own account")
+		return
+	}
+
+	// Check if user exists
+	user, err := h.storage.Users().GetByID(ctx, userID)
+	if err != nil {
+		log.Printf("delete user error: get user: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+	if user == nil {
+		jsonError(w, http.StatusNotFound, errCodeNotFound, "user not found")
+		return
+	}
+
+	// Delete user
+	if err := h.storage.Users().Delete(ctx, userID); err != nil {
+		log.Printf("delete user error: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+
+	log.Printf("user deleted: %s (%s)", user.Username, user.ID)
+
+	jsonNoContent(w)
+}
+
+// GetCurrentUser returns the current authenticated user.
+func (h *Handler) GetCurrentUser(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	userID := middleware.GetUserID(ctx)
+
+	user, err := h.storage.Users().GetByID(ctx, userID)
+	if err != nil {
+		log.Printf("get current user error: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+	if user == nil {
+		jsonError(w, http.StatusNotFound, errCodeNotFound, "user not found")
+		return
+	}
+
+	jsonOK(w, userToResponse(user))
+}
+
+// ChangePassword changes the current user's password.
+func (h *Handler) ChangePassword(w http.ResponseWriter, r *http.Request) {
+	var req ChangePasswordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, errCodeBadRequest, "invalid request body")
+		return
+	}
+
+	if req.CurrentPassword == "" {
+		jsonError(w, http.StatusBadRequest, errCodeValidationFailed, "current_password is required")
+		return
+	}
+	if err := auth.ValidatePasswordOrError(req.NewPassword); err != nil {
+		jsonError(w, http.StatusBadRequest, errCodeValidationFailed, err.Error())
+		return
+	}
+
+	ctx := r.Context()
+	userID := middleware.GetUserID(ctx)
+
+	// Get user
+	user, err := h.storage.Users().GetByID(ctx, userID)
+	if err != nil {
+		log.Printf("change password error: get user: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+	if user == nil {
+		jsonError(w, http.StatusNotFound, errCodeNotFound, "user not found")
+		return
+	}
+
+	// Verify current password
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.CurrentPassword)); err != nil {
+		jsonError(w, http.StatusBadRequest, errCodeValidationFailed, "current password is incorrect")
+		return
+	}
+
+	// Hash new password
+	hash, err := bcrypt.GenerateFromPassword([]byte(req.NewPassword), bcrypt.DefaultCost)
+	if err != nil {
+		log.Printf("change password error: hash password: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+
+	user.PasswordHash = string(hash)
+	user.UpdatedAt = time.Now()
+
+	if err := h.storage.Users().Update(ctx, user); err != nil {
+		log.Printf("change password error: %v", err)
+		jsonError(w, http.StatusInternalServerError, errCodeInternalError, "internal server error")
+		return
+	}
+
+	// Revoke all refresh tokens (force re-login on other devices)
+	if err := h.storage.Tokens().RevokeAllForUser(ctx, userID); err != nil {
+		log.Printf("change password warning: revoke tokens: %v", err)
+		// Don't fail the request, password was already changed
+	}
+
+	log.Printf("password changed: user %s", user.Username)
+
+	jsonNoContent(w)
+}
+
+// userToResponse converts a User to UserResponse.
+func userToResponse(u *models.User) *UserResponse {
+	return &UserResponse{
+		ID:        u.ID,
+		Username:  u.Username,
+		Email:     u.Email,
+		Role:      string(u.Role),
+		CreatedAt: u.CreatedAt.Format(time.RFC3339),
+		UpdatedAt: u.UpdatedAt.Format(time.RFC3339),
+	}
+}

--- a/internal/api/users/validation.go
+++ b/internal/api/users/validation.go
@@ -1,0 +1,72 @@
+// Package users provides user management API endpoints.
+package users
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+var (
+	usernameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]{2,31}$`)
+	emailRegex    = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+)
+
+// ValidationError contains validation error details.
+type ValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+func (e *ValidationError) Error() string {
+	return e.Message
+}
+
+// ValidateUsername validates a username.
+func ValidateUsername(username string) error {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return &ValidationError{Field: "username", Message: "username is required"}
+	}
+	if len(username) < 3 {
+		return &ValidationError{Field: "username", Message: "username must be at least 3 characters"}
+	}
+	if len(username) > 32 {
+		return &ValidationError{Field: "username", Message: "username must be at most 32 characters"}
+	}
+	if !usernameRegex.MatchString(username) {
+		return &ValidationError{Field: "username", Message: "username must start with a letter and contain only letters, numbers, underscores, or hyphens"}
+	}
+	return nil
+}
+
+// ValidateEmail validates an email address.
+func ValidateEmail(email string) error {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return &ValidationError{Field: "email", Message: "email is required"}
+	}
+	if len(email) > 255 {
+		return &ValidationError{Field: "email", Message: "email must be at most 255 characters"}
+	}
+	if !emailRegex.MatchString(email) {
+		return &ValidationError{Field: "email", Message: "invalid email format"}
+	}
+	return nil
+}
+
+// ValidateRole validates a role string.
+func ValidateRole(role string) (models.Role, error) {
+	role = strings.TrimSpace(strings.ToLower(role))
+	switch role {
+	case "admin":
+		return models.RoleAdmin, nil
+	case "operator":
+		return models.RoleOperator, nil
+	case "viewer":
+		return models.RoleViewer, nil
+	default:
+		return "", &ValidationError{Field: "role", Message: "role must be one of: admin, operator, viewer"}
+	}
+}

--- a/internal/models/token.go
+++ b/internal/models/token.go
@@ -1,0 +1,61 @@
+package models
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"time"
+)
+
+// RefreshToken represents a JWT refresh token stored in the database.
+type RefreshToken struct {
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	TokenHash string    `json:"-"` // SHA-256 hash of the actual token
+	ExpiresAt time.Time `json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+	Revoked   bool      `json:"revoked"`
+	RevokedAt *time.Time `json:"revoked_at,omitempty"`
+}
+
+// NewRefreshToken creates a new RefreshToken with generated token.
+// Returns the token model and the plaintext token to send to the client.
+func NewRefreshToken(userID string, ttl time.Duration) (*RefreshToken, string, error) {
+	// Generate 32 random bytes
+	tokenBytes := make([]byte, 32)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return nil, "", err
+	}
+
+	// Encode as base64url
+	plainToken := base64.RawURLEncoding.EncodeToString(tokenBytes)
+
+	// Hash for storage
+	hash := sha256.Sum256([]byte(plainToken))
+	tokenHash := base64.RawURLEncoding.EncodeToString(hash[:])
+
+	now := time.Now()
+	return &RefreshToken{
+		UserID:    userID,
+		TokenHash: tokenHash,
+		ExpiresAt: now.Add(ttl),
+		CreatedAt: now,
+		Revoked:   false,
+	}, plainToken, nil
+}
+
+// HashToken creates a SHA-256 hash of a plaintext token for lookup.
+func HashToken(plainToken string) string {
+	hash := sha256.Sum256([]byte(plainToken))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+// IsExpired returns true if the token has expired.
+func (t *RefreshToken) IsExpired() bool {
+	return time.Now().After(t.ExpiresAt)
+}
+
+// IsValid returns true if the token is not revoked and not expired.
+func (t *RefreshToken) IsValid() bool {
+	return !t.Revoked && !t.IsExpired()
+}

--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -93,6 +93,28 @@ var migrations = []Migration{
 			CREATE INDEX IF NOT EXISTS idx_connections_name ON connections(name);
 		`,
 	},
+	{
+		Version: 2,
+		Name:    "add_refresh_tokens",
+		Up: `
+			-- Refresh tokens table for JWT refresh token management
+			CREATE TABLE IF NOT EXISTS refresh_tokens (
+				id TEXT PRIMARY KEY,
+				user_id TEXT NOT NULL,
+				token_hash TEXT NOT NULL UNIQUE,
+				expires_at DATETIME NOT NULL,
+				created_at DATETIME NOT NULL,
+				revoked INTEGER DEFAULT 0,
+				revoked_at DATETIME,
+				FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+			);
+
+			-- Indexes for efficient lookups
+			CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_id ON refresh_tokens(user_id);
+			CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token_hash ON refresh_tokens(token_hash);
+			CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires_at ON refresh_tokens(expires_at);
+		`,
+	},
 }
 
 // runMigrations applies all pending migrations.

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -25,6 +25,7 @@ type SQLiteStorage struct {
 	projects    *sqliteProjectRepo
 	alerts      *sqliteAlertRepo
 	connections *sqliteConnectionRepo
+	tokens      *sqliteTokenRepo
 }
 
 // NewSQLiteStorage creates a new SQLite storage.
@@ -75,6 +76,7 @@ func (s *SQLiteStorage) Open() error {
 	s.projects = &sqliteProjectRepo{db: db}
 	s.alerts = &sqliteAlertRepo{db: db}
 	s.connections = &sqliteConnectionRepo{db: db, masterKey: s.masterKey}
+	s.tokens = &sqliteTokenRepo{db: db}
 
 	return nil
 }
@@ -153,6 +155,11 @@ func (s *SQLiteStorage) Alerts() AlertRepository {
 // Connections returns the connection repository.
 func (s *SQLiteStorage) Connections() ConnectionRepository {
 	return s.connections
+}
+
+// Tokens returns the token repository.
+func (s *SQLiteStorage) Tokens() TokenRepository {
+	return s.tokens
 }
 
 // generateRandomPassword generates a random password of the specified length.

--- a/internal/storage/sqlite_tokens.go
+++ b/internal/storage/sqlite_tokens.go
@@ -1,0 +1,148 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+// sqliteTokenRepo implements TokenRepository using SQLite.
+type sqliteTokenRepo struct {
+	db *sql.DB
+}
+
+// Create inserts a new refresh token.
+func (r *sqliteTokenRepo) Create(ctx context.Context, token *models.RefreshToken) error {
+	if token.ID == "" {
+		token.ID = uuid.New().String()
+	}
+
+	query := `
+		INSERT INTO refresh_tokens (id, user_id, token_hash, expires_at, created_at, revoked)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`
+
+	_, err := r.db.ExecContext(ctx, query,
+		token.ID,
+		token.UserID,
+		token.TokenHash,
+		token.ExpiresAt,
+		token.CreatedAt,
+		boolToInt(token.Revoked),
+	)
+	if err != nil {
+		return fmt.Errorf("insert refresh token: %w", err)
+	}
+
+	return nil
+}
+
+// GetByTokenHash retrieves a refresh token by its hash.
+func (r *sqliteTokenRepo) GetByTokenHash(ctx context.Context, tokenHash string) (*models.RefreshToken, error) {
+	query := `
+		SELECT id, user_id, token_hash, expires_at, created_at, revoked, revoked_at
+		FROM refresh_tokens
+		WHERE token_hash = ?
+	`
+
+	var token models.RefreshToken
+	var revokedAt sql.NullTime
+	var revoked int
+
+	err := r.db.QueryRowContext(ctx, query, tokenHash).Scan(
+		&token.ID,
+		&token.UserID,
+		&token.TokenHash,
+		&token.ExpiresAt,
+		&token.CreatedAt,
+		&revoked,
+		&revokedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query refresh token: %w", err)
+	}
+
+	token.Revoked = revoked != 0
+	if revokedAt.Valid {
+		token.RevokedAt = &revokedAt.Time
+	}
+
+	return &token, nil
+}
+
+// Revoke marks a token as revoked.
+func (r *sqliteTokenRepo) Revoke(ctx context.Context, id string) error {
+	query := `
+		UPDATE refresh_tokens
+		SET revoked = 1, revoked_at = ?
+		WHERE id = ?
+	`
+
+	result, err := r.db.ExecContext(ctx, query, time.Now(), id)
+	if err != nil {
+		return fmt.Errorf("revoke token: %w", err)
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("token not found")
+	}
+
+	return nil
+}
+
+// RevokeByTokenHash revokes a token by its hash.
+func (r *sqliteTokenRepo) RevokeByTokenHash(ctx context.Context, tokenHash string) error {
+	query := `
+		UPDATE refresh_tokens
+		SET revoked = 1, revoked_at = ?
+		WHERE token_hash = ?
+	`
+
+	_, err := r.db.ExecContext(ctx, query, time.Now(), tokenHash)
+	if err != nil {
+		return fmt.Errorf("revoke token by hash: %w", err)
+	}
+
+	return nil
+}
+
+// RevokeAllForUser revokes all tokens for a user.
+func (r *sqliteTokenRepo) RevokeAllForUser(ctx context.Context, userID string) error {
+	query := `
+		UPDATE refresh_tokens
+		SET revoked = 1, revoked_at = ?
+		WHERE user_id = ? AND revoked = 0
+	`
+
+	_, err := r.db.ExecContext(ctx, query, time.Now(), userID)
+	if err != nil {
+		return fmt.Errorf("revoke all tokens for user: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteExpired removes expired tokens from the database.
+func (r *sqliteTokenRepo) DeleteExpired(ctx context.Context) (int64, error) {
+	query := `
+		DELETE FROM refresh_tokens
+		WHERE expires_at < ?
+	`
+
+	result, err := r.db.ExecContext(ctx, query, time.Now())
+	if err != nil {
+		return 0, fmt.Errorf("delete expired tokens: %w", err)
+	}
+
+	return result.RowsAffected()
+}
+

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -24,6 +24,7 @@ type Storage interface {
 	Projects() ProjectRepository
 	Alerts() AlertRepository
 	Connections() ConnectionRepository
+	Tokens() TokenRepository
 }
 
 // UserRepository defines operations for user management.
@@ -74,4 +75,14 @@ type ConnectionRepository interface {
 	List(ctx context.Context) ([]*models.Connection, error)
 	ListByProject(ctx context.Context, projectID string) ([]*models.Connection, error)
 	UpdateStatus(ctx context.Context, id string, status models.ConnectionStatus, testedAt time.Time) error
+}
+
+// TokenRepository defines operations for refresh token management.
+type TokenRepository interface {
+	Create(ctx context.Context, token *models.RefreshToken) error
+	GetByTokenHash(ctx context.Context, tokenHash string) (*models.RefreshToken, error)
+	Revoke(ctx context.Context, id string) error
+	RevokeByTokenHash(ctx context.Context, tokenHash string) error
+	RevokeAllForUser(ctx context.Context, userID string) error
+	DeleteExpired(ctx context.Context) (int64, error)
 }


### PR DESCRIPTION
## Summary
- Add REST API with JWT authentication and refresh tokens
- Implement user management endpoints with RBAC
- Add rate limiting (per-IP for login, per-user for API)
- Add account lockout after failed attempts
- Add password complexity validation
- Add security headers middleware

## Test plan
- [x] Unit tests for JWT service
- [x] Unit tests for password validation
- [x] Unit tests for lockout tracker
- [x] Unit tests for auth/RBAC middleware
- [x] Integration tests for full auth flow
- [ ] Manual testing of endpoints

Closes #22