### PR TITLE
23 - Add REST API for log query, stats, SSE streaming

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -51,13 +51,15 @@ func (c *Config) SetDefaults() {
 
 // Server is the HTTP API server.
 type Server struct {
-	config  *Config
-	storage storage.Storage
-	server  *http.Server
+	config     *Config
+	storage    storage.Storage
+	logStorage storage.LogStorage
+	server     *http.Server
 }
 
 // New creates a new API server.
-func New(cfg *Config, store storage.Storage) (*Server, error) {
+// logStore can be nil if ClickHouse is disabled.
+func New(cfg *Config, store storage.Storage, logStore storage.LogStorage) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is required")
 	}
@@ -71,8 +73,9 @@ func New(cfg *Config, store storage.Storage) (*Server, error) {
 	cfg.SetDefaults()
 
 	s := &Server{
-		config:  cfg,
-		storage: store,
+		config:     cfg,
+		storage:    store,
+		logStorage: logStore,
 	}
 
 	router := s.setupRouter()

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -51,7 +51,7 @@ func testServer(t *testing.T) (*Server, storage.Storage, func()) {
 		Verbose:          false,
 	}
 
-	srv, err := New(cfg, store)
+	srv, err := New(cfg, store, nil) // nil logStorage - ClickHouse not used in tests
 	if err != nil {
 		store.Close()
 		os.Remove(tmpFile.Name())

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/good-yellow-bee/blazelog/internal/api/auth"
+	"github.com/good-yellow-bee/blazelog/internal/api/logs"
 	"github.com/good-yellow-bee/blazelog/internal/api/middleware"
 	"github.com/good-yellow-bee/blazelog/internal/api/users"
 	"github.com/good-yellow-bee/blazelog/internal/models"
@@ -85,6 +86,18 @@ func (s *Server) setupRouter() *chi.Mux {
 					r.Delete("/", userHandler.Delete)
 				})
 			})
+		})
+
+		// Log routes (protected - any authenticated user can view)
+		r.Route("/logs", func(r chi.Router) {
+			r.Use(middleware.JWTAuth(jwtService))
+			r.Use(middleware.RateLimitByUser(userLimiter))
+
+			logsHandler := logs.NewHandler(s.logStorage)
+
+			r.Get("/", logsHandler.Query)
+			r.Get("/stats", logsHandler.Stats)
+			r.Get("/stream", logsHandler.Stream)
 		})
 	})
 


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/logs` endpoint for log queries with filters (level, type, source, agent_id, time range), pagination, and search modes (token/substring/phrase)
- Add `GET /api/v1/logs/stats` endpoint for aggregated statistics (error rates, volume over time, top sources, HTTP stats)
- Add `GET /api/v1/logs/stream` endpoint for real-time SSE streaming with heartbeats and timeout handling
- Extend `api.Server` with `logStorage` field to access ClickHouse
- 81% test coverage for logs package

## Test plan
- [ ] Verify log query endpoint with various filters
- [ ] Verify pagination works correctly
- [ ] Verify stats endpoint returns aggregated data
- [ ] Verify SSE streaming connects and receives logs
- [ ] Verify auth middleware protects all /logs endpoints
- [ ] Run full test suite: `go test ./...`

Closes #23