### PR TITLE
29 - Add batch processing with analyze CLI command

### DIFF
--- a/cmd/blazectl/cmd/analyze.go
+++ b/cmd/blazectl/cmd/analyze.go
@@ -1,0 +1,304 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"sort"
+	"syscall"
+	"text/tabwriter"
+
+	"github.com/good-yellow-bee/blazelog/internal/batch"
+	"github.com/spf13/cobra"
+)
+
+var (
+	analyzeFrom     string
+	analyzeTo       string
+	analyzeWorkers  int
+	analyzeParser   string
+	analyzeExport   string
+	analyzeExportTo string
+	analyzeLimit    int
+)
+
+var analyzeCmd = &cobra.Command{
+	Use:   "analyze [file...]",
+	Short: "Batch analyze log files",
+	Long: `Analyze log files with date range filtering and parallel processing.
+
+Supports glob patterns for analyzing multiple files at once.
+Generates summary statistics with optional export to CSV or JSON.
+
+Examples:
+  # Analyze logs from January 2024
+  blazelog analyze /var/log/*.log --from 2024-01-01 --to 2024-01-31
+
+  # Analyze with JSON output
+  blazelog analyze /var/log/nginx/*.log -o json
+
+  # Parallel processing with 8 workers
+  blazelog analyze /var/log/*.log --workers 8
+
+  # Export results to CSV
+  blazelog analyze /var/log/*.log --export csv --export-to report.csv
+
+  # Specify parser type
+  blazelog analyze /var/log/*.log --parser nginx
+
+  # Analyze with verbose progress
+  blazelog analyze /var/log/*.log -v`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: runAnalyze,
+}
+
+func init() {
+	rootCmd.AddCommand(analyzeCmd)
+
+	analyzeCmd.Flags().StringVar(&analyzeFrom, "from", "", "filter entries after date (YYYY-MM-DD or RFC3339)")
+	analyzeCmd.Flags().StringVar(&analyzeTo, "to", "", "filter entries before date (YYYY-MM-DD or RFC3339)")
+	analyzeCmd.Flags().IntVar(&analyzeWorkers, "workers", 0, "number of parallel workers (0 = auto)")
+	analyzeCmd.Flags().StringVarP(&analyzeParser, "parser", "p", "auto", "parser type (nginx, apache, magento, prestashop, wordpress, auto)")
+	analyzeCmd.Flags().StringVar(&analyzeExport, "export", "", "export format (json, csv)")
+	analyzeCmd.Flags().StringVar(&analyzeExportTo, "export-to", "", "export file path (default: stdout)")
+	analyzeCmd.Flags().IntVarP(&analyzeLimit, "limit", "n", 0, "limit entries per file (0 = no limit)")
+}
+
+func runAnalyze(cmd *cobra.Command, args []string) error {
+	// Parse date flags
+	from, err := batch.ParseDateFlag(analyzeFrom)
+	if err != nil {
+		return fmt.Errorf("invalid --from: %w", err)
+	}
+
+	to, err := batch.ParseDateFlagEndOfDay(analyzeTo)
+	if err != nil {
+		return fmt.Errorf("invalid --to: %w", err)
+	}
+
+	// Create analyzer options
+	opts := &batch.AnalyzerOptions{
+		Workers:    analyzeWorkers,
+		From:       from,
+		To:         to,
+		ParserType: analyzeParser,
+		Verbose:    IsVerbose(),
+		Limit:      analyzeLimit,
+	}
+
+	// Create context with cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Handle signals
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		PrintVerbose("Received interrupt, stopping...")
+		cancel()
+	}()
+
+	// Create and run analyzer
+	analyzer := batch.NewAnalyzer(opts)
+
+	PrintVerbose("Analyzing files with %d workers...", opts.Workers)
+
+	report, err := analyzer.Analyze(ctx, args)
+	if err != nil {
+		return err
+	}
+
+	// Handle export if requested
+	if analyzeExport != "" {
+		format, ok := batch.ParseExportFormat(analyzeExport)
+		if !ok {
+			return fmt.Errorf("invalid export format: %s (use json or csv)", analyzeExport)
+		}
+
+		var writer = os.Stdout
+		if analyzeExportTo != "" {
+			file, err := os.Create(analyzeExportTo)
+			if err != nil {
+				return fmt.Errorf("create export file: %w", err)
+			}
+			defer file.Close()
+			writer = file
+		}
+
+		exporter := batch.NewExporter(format, writer)
+		if err := exporter.ExportReport(report); err != nil {
+			return fmt.Errorf("export: %w", err)
+		}
+
+		if analyzeExportTo != "" {
+			PrintVerbose("Report exported to %s", analyzeExportTo)
+		}
+		return nil
+	}
+
+	// Output report based on format
+	outputReport(report)
+	return nil
+}
+
+func outputReport(report *batch.Report) {
+	switch GetOutput() {
+	case "json":
+		outputReportJSON(report)
+	case "plain":
+		outputReportPlain(report)
+	default:
+		outputReportTable(report)
+	}
+}
+
+func outputReportJSON(report *batch.Report) {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		PrintError(fmt.Sprintf("failed to marshal JSON: %v", err), false)
+		return
+	}
+	fmt.Println(string(data))
+}
+
+func outputReportPlain(report *batch.Report) {
+	s := report.Summary
+	fmt.Printf("Files: %d | Entries: %d | Errors: %d | Parse Errors: %d\n",
+		s.TotalFiles, s.TotalEntries, s.TotalErrors, s.ParseErrors)
+	fmt.Printf("Duration: %v | Throughput: %.0f entries/sec\n",
+		report.Duration.Round(1e6), s.EntriesPerSec)
+}
+
+func outputReportTable(report *batch.Report) {
+	s := report.Summary
+
+	// Header
+	fmt.Println()
+	fmt.Println("Batch Analysis Report")
+	fmt.Println("=====================")
+
+	// Date range
+	if report.DateRange != nil {
+		if report.DateRange.Filtered {
+			fmt.Printf("Date Filter: %s → %s\n",
+				formatDate(report.DateRange.From),
+				formatDate(report.DateRange.To))
+		}
+		if !report.DateRange.Earliest.IsZero() {
+			fmt.Printf("Actual Range: %s → %s\n",
+				report.DateRange.Earliest.Format("2006-01-02 15:04:05"),
+				report.DateRange.Latest.Format("2006-01-02 15:04:05"))
+		}
+	}
+
+	fmt.Printf("Files: %d | Duration: %v | Throughput: %.0f entries/sec\n",
+		s.TotalFiles, report.Duration.Round(1e6), s.EntriesPerSec)
+	fmt.Println()
+
+	// Summary
+	fmt.Println("Summary:")
+	fmt.Printf("  Total Entries:  %d\n", s.TotalEntries)
+	fmt.Printf("  Total Errors:   %d\n", s.TotalErrors)
+	fmt.Printf("  Parse Errors:   %d\n", s.ParseErrors)
+	fmt.Println()
+
+	// By Level
+	if len(s.LevelCounts) > 0 {
+		fmt.Println("By Level:")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintf(w, "  LEVEL\tCOUNT\t%%\n")
+		fmt.Fprintf(w, "  -----\t-----\t-\n")
+
+		// Sort levels for consistent output
+		levels := sortedKeys(s.LevelCounts)
+		for _, level := range levels {
+			count := s.LevelCounts[level]
+			pct := s.LevelPercentage(level)
+			fmt.Fprintf(w, "  %s\t%d\t%.1f%%\n", level, count, pct)
+		}
+		w.Flush()
+		fmt.Println()
+	}
+
+	// By Type
+	if len(s.TypeCounts) > 0 {
+		fmt.Println("By Type:")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintf(w, "  TYPE\tCOUNT\t%%\n")
+		fmt.Fprintf(w, "  ----\t-----\t-\n")
+
+		types := sortedKeys(s.TypeCounts)
+		for _, typ := range types {
+			count := s.TypeCounts[typ]
+			pct := s.TypePercentage(typ)
+			fmt.Fprintf(w, "  %s\t%d\t%.1f%%\n", typ, count, pct)
+		}
+		w.Flush()
+		fmt.Println()
+	}
+
+	// Top Sources (show top 10)
+	if len(s.SourceCounts) > 0 && IsVerbose() {
+		fmt.Println("Top Sources:")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintf(w, "  SOURCE\tCOUNT\n")
+		fmt.Fprintf(w, "  ------\t-----\n")
+
+		sources := sortedKeysByValue(s.SourceCounts)
+		limit := 10
+		if len(sources) < limit {
+			limit = len(sources)
+		}
+		for i := 0; i < limit; i++ {
+			src := sources[i]
+			fmt.Fprintf(w, "  %s\t%d\n", src, s.SourceCounts[src])
+		}
+		w.Flush()
+		fmt.Println()
+	}
+
+	// Errors
+	if len(report.Errors) > 0 {
+		fmt.Printf("Warnings (%d):\n", len(report.Errors))
+		for i, err := range report.Errors {
+			if i >= 5 {
+				fmt.Printf("  ... and %d more\n", len(report.Errors)-5)
+				break
+			}
+			fmt.Printf("  - %s\n", err)
+		}
+		fmt.Println()
+	}
+}
+
+func formatDate(t interface{}) string {
+	switch v := t.(type) {
+	case string:
+		return v
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func sortedKeys(m map[string]int64) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedKeysByValue(m map[string]int64) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return m[keys[i]] > m[keys[j]]
+	})
+	return keys
+}

--- a/internal/batch/analyzer.go
+++ b/internal/batch/analyzer.go
@@ -1,0 +1,432 @@
+package batch
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+	"github.com/good-yellow-bee/blazelog/internal/parser"
+)
+
+// AnalyzerOptions configures batch analysis.
+type AnalyzerOptions struct {
+	Workers    int       // Number of parallel workers (0 = auto)
+	BufferSize int       // Channel buffer size (0 = auto)
+	From       time.Time // Filter: entries on or after this time
+	To         time.Time // Filter: entries on or before this time
+	ParserType string    // Parser type ("nginx", "apache", etc) or "auto"
+	Verbose    bool      // Verbose progress output
+	Limit      int       // Limit entries per file (0 = no limit)
+}
+
+// DefaultOptions returns sensible defaults.
+func DefaultOptions() *AnalyzerOptions {
+	return &AnalyzerOptions{
+		Workers:    runtime.NumCPU(),
+		BufferSize: 0, // Will be set based on workers
+		ParserType: "auto",
+		Verbose:    false,
+		Limit:      0,
+	}
+}
+
+// Analyzer performs batch analysis on log files.
+type Analyzer struct {
+	opts   *AnalyzerOptions
+	filter *DateFilter
+}
+
+// NewAnalyzer creates a new batch analyzer.
+func NewAnalyzer(opts *AnalyzerOptions) *Analyzer {
+	if opts == nil {
+		opts = DefaultOptions()
+	}
+	if opts.Workers <= 0 {
+		opts.Workers = runtime.NumCPU()
+	}
+
+	return &Analyzer{
+		opts:   opts,
+		filter: NewDateFilter(opts.From, opts.To),
+	}
+}
+
+// Analyze processes files matching the given patterns and returns aggregated stats.
+func (a *Analyzer) Analyze(ctx context.Context, patterns []string) (*Report, error) {
+	startTime := time.Now()
+
+	// Expand glob patterns to file list
+	files := expandGlobs(patterns)
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no files match the specified patterns")
+	}
+
+	// Create worker pool
+	pool := NewWorkerPool(a.opts.Workers, a.opts.BufferSize)
+
+	// Start workers with our file processor
+	pool.Start(ctx, a.analyzeFile)
+
+	// Submit all files
+	go func() {
+		for _, f := range files {
+			if err := pool.Submit(ctx, f); err != nil {
+				break
+			}
+		}
+		pool.Close()
+	}()
+
+	// Collect results
+	var results []*FileStats
+	var errors []string
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	// Collect results from pool
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for stats := range pool.Results() {
+			mu.Lock()
+			results = append(results, stats)
+			mu.Unlock()
+		}
+	}()
+
+	// Collect errors from pool
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for err := range pool.Errors() {
+			mu.Lock()
+			errors = append(errors, err.Error())
+			mu.Unlock()
+		}
+	}()
+
+	wg.Wait()
+
+	endTime := time.Now()
+	duration := endTime.Sub(startTime)
+
+	// Build report
+	report := &Report{
+		StartTime: startTime,
+		EndTime:   endTime,
+		Duration:  duration,
+		Files:     results,
+		Summary:   Aggregate(results, duration),
+		Errors:    errors,
+	}
+
+	// Add date range info
+	if a.filter.Enabled {
+		report.DateRange = &DateRange{
+			Filtered: true,
+			From:     a.opts.From,
+			To:       a.opts.To,
+		}
+	}
+
+	// Calculate actual date range from entries
+	for _, f := range results {
+		if report.DateRange == nil {
+			report.DateRange = &DateRange{}
+		}
+		if !f.FirstEntry.IsZero() {
+			if report.DateRange.Earliest.IsZero() || f.FirstEntry.Before(report.DateRange.Earliest) {
+				report.DateRange.Earliest = f.FirstEntry
+			}
+		}
+		if !f.LastEntry.IsZero() {
+			if report.DateRange.Latest.IsZero() || f.LastEntry.After(report.DateRange.Latest) {
+				report.DateRange.Latest = f.LastEntry
+			}
+		}
+	}
+
+	return report, nil
+}
+
+// analyzeFile processes a single file and returns stats.
+func (a *Analyzer) analyzeFile(ctx context.Context, path string) (*FileStats, error) {
+	parseStart := time.Now()
+	stats := NewFileStats(path)
+
+	// Open file
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer file.Close()
+
+	// Get file size
+	if fi, err := file.Stat(); err == nil {
+		stats.BytesRead = fi.Size()
+	}
+
+	// Get parser
+	p, err := a.getParser(file, path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Reset file after auto-detection
+	if _, err := file.Seek(0, 0); err != nil {
+		return nil, fmt.Errorf("seek %s: %w", path, err)
+	}
+
+	// Check if this is a multiline parser
+	multiParser, isMultiLine := p.(parser.MultiLineParser)
+
+	scanner := bufio.NewScanner(file)
+	// Increase buffer for potentially long lines
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	if isMultiLine {
+		stats.ParseErrors, stats.ParsedCount, stats.ErrorCount = a.parseMultiLine(ctx, scanner, multiParser, stats, path)
+	} else {
+		stats.ParseErrors, stats.ParsedCount, stats.ErrorCount = a.parseSingleLine(ctx, scanner, p, stats, path)
+	}
+
+	stats.ParseTime = time.Since(parseStart)
+	return stats, scanner.Err()
+}
+
+func (a *Analyzer) parseSingleLine(ctx context.Context, scanner *bufio.Scanner, p parser.Parser, stats *FileStats, path string) (parseErrors, parsed, errors int64) {
+	lineNum := int64(0)
+	count := 0
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		lineNum++
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		entry, err := p.Parse(line)
+		if err != nil {
+			parseErrors++
+			continue
+		}
+
+		entry.LineNumber = lineNum
+		entry.FilePath = path
+
+		// Apply date filter
+		if !a.filter.Matches(entry) {
+			continue
+		}
+
+		// Update stats
+		parsed++
+		stats.LevelCounts[string(entry.Level)]++
+		stats.TypeCounts[string(entry.Type)]++
+
+		if entry.Level == models.LevelError || entry.Level == models.LevelFatal {
+			errors++
+		}
+
+		// Track time range
+		if !entry.Timestamp.IsZero() {
+			if stats.FirstEntry.IsZero() || entry.Timestamp.Before(stats.FirstEntry) {
+				stats.FirstEntry = entry.Timestamp
+			}
+			if stats.LastEntry.IsZero() || entry.Timestamp.After(stats.LastEntry) {
+				stats.LastEntry = entry.Timestamp
+			}
+		}
+
+		count++
+		if a.opts.Limit > 0 && count >= a.opts.Limit {
+			break
+		}
+	}
+
+	return
+}
+
+func (a *Analyzer) parseMultiLine(ctx context.Context, scanner *bufio.Scanner, p parser.MultiLineParser, stats *FileStats, path string) (parseErrors, parsed, errors int64) {
+	var currentLines []string
+	var startLineNum int64
+	lineNum := int64(0)
+	count := 0
+
+	processEntry := func() {
+		if len(currentLines) == 0 {
+			return
+		}
+
+		entry, err := p.ParseMultiLine(currentLines)
+		if err != nil {
+			parseErrors++
+			return
+		}
+
+		entry.LineNumber = startLineNum
+		entry.FilePath = path
+
+		// Apply date filter
+		if !a.filter.Matches(entry) {
+			return
+		}
+
+		// Update stats
+		parsed++
+		stats.LevelCounts[string(entry.Level)]++
+		stats.TypeCounts[string(entry.Type)]++
+
+		if entry.Level == models.LevelError || entry.Level == models.LevelFatal {
+			errors++
+		}
+
+		// Track time range
+		if !entry.Timestamp.IsZero() {
+			if stats.FirstEntry.IsZero() || entry.Timestamp.Before(stats.FirstEntry) {
+				stats.FirstEntry = entry.Timestamp
+			}
+			if stats.LastEntry.IsZero() || entry.Timestamp.After(stats.LastEntry) {
+				stats.LastEntry = entry.Timestamp
+			}
+		}
+
+		count++
+	}
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		lineNum++
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		if p.IsStartOfEntry(line) {
+			// Process previous entry
+			processEntry()
+			if a.opts.Limit > 0 && count >= a.opts.Limit {
+				break
+			}
+
+			// Start new entry
+			currentLines = []string{line}
+			startLineNum = lineNum
+		} else if len(currentLines) > 0 {
+			currentLines = append(currentLines, line)
+		}
+	}
+
+	// Process last entry
+	if a.opts.Limit == 0 || count < a.opts.Limit {
+		processEntry()
+	}
+
+	return
+}
+
+func (a *Analyzer) getParser(file *os.File, path string) (parser.Parser, error) {
+	if a.opts.ParserType != "" && a.opts.ParserType != "auto" {
+		p, ok := GetParser(a.opts.ParserType)
+		if !ok {
+			return nil, fmt.Errorf("unknown parser type: %s", a.opts.ParserType)
+		}
+		return p, nil
+	}
+
+	// Auto-detect from first line
+	scanner := bufio.NewScanner(file)
+	var firstLine string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line != "" {
+			firstLine = line
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	if firstLine == "" {
+		return nil, fmt.Errorf("file is empty: %s", path)
+	}
+
+	p, ok := parser.AutoDetect(firstLine)
+	if !ok {
+		return nil, fmt.Errorf("could not auto-detect format for: %s", path)
+	}
+
+	return p, nil
+}
+
+// GetParser returns a parser for the given type.
+func GetParser(logType string) (parser.Parser, bool) {
+	switch logType {
+	case "nginx", "nginx-access":
+		return parser.NewNginxAccessParser(nil), true
+	case "nginx-error":
+		return parser.NewNginxErrorParser(nil), true
+	case "apache", "apache-access":
+		return parser.NewApacheAccessParser(nil), true
+	case "apache-error":
+		return parser.NewApacheErrorParser(nil), true
+	case "magento":
+		return parser.NewMagentoParser(nil), true
+	case "prestashop":
+		return parser.NewPrestaShopParser(nil), true
+	case "wordpress":
+		return parser.NewWordPressParser(nil), true
+	default:
+		return nil, false
+	}
+}
+
+// expandGlobs expands glob patterns to absolute file paths.
+func expandGlobs(patterns []string) []string {
+	var files []string
+	seen := make(map[string]bool)
+
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			continue
+		}
+
+		for _, match := range matches {
+			// Skip directories
+			fi, err := os.Stat(match)
+			if err != nil || fi.IsDir() {
+				continue
+			}
+
+			absPath, err := filepath.Abs(match)
+			if err != nil {
+				continue
+			}
+
+			if !seen[absPath] {
+				seen[absPath] = true
+				files = append(files, absPath)
+			}
+		}
+	}
+
+	return files
+}

--- a/internal/batch/batch_test.go
+++ b/internal/batch/batch_test.go
@@ -1,0 +1,427 @@
+package batch
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+// Test data directory
+const testDataDir = "testdata"
+
+func setupTestData(t *testing.T) string {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), testDataDir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("create testdata dir: %v", err)
+	}
+
+	// Create nginx log file
+	nginxLog := `192.168.1.1 - - [01/Jan/2024:10:00:00 +0000] "GET /index.html HTTP/1.1" 200 1234 "-" "Mozilla/5.0"
+192.168.1.2 - - [01/Jan/2024:10:00:01 +0000] "POST /api/users HTTP/1.1" 201 567 "-" "curl/7.68.0"
+192.168.1.3 - - [01/Jan/2024:10:00:02 +0000] "GET /missing HTTP/1.1" 404 123 "-" "Mozilla/5.0"
+192.168.1.4 - - [01/Jan/2024:10:00:03 +0000] "GET /error HTTP/1.1" 500 456 "-" "Mozilla/5.0"`
+
+	if err := os.WriteFile(filepath.Join(dir, "access.log"), []byte(nginxLog), 0644); err != nil {
+		t.Fatalf("write nginx log: %v", err)
+	}
+
+	// Create another nginx log file
+	nginxLog2 := `192.168.1.5 - - [02/Jan/2024:10:00:00 +0000] "GET /page HTTP/1.1" 200 789 "-" "Mozilla/5.0"
+192.168.1.6 - - [02/Jan/2024:10:00:01 +0000] "GET /other HTTP/1.1" 200 321 "-" "Mozilla/5.0"`
+
+	if err := os.WriteFile(filepath.Join(dir, "access2.log"), []byte(nginxLog2), 0644); err != nil {
+		t.Fatalf("write nginx log 2: %v", err)
+	}
+
+	return dir
+}
+
+func TestDateFilter_Matches(t *testing.T) {
+	tests := []struct {
+		name    string
+		from    time.Time
+		to      time.Time
+		ts      time.Time
+		want    bool
+	}{
+		{
+			name: "disabled filter matches all",
+			want: true,
+		},
+		{
+			name: "from only - matches after",
+			from: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			ts:   time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			want: true,
+		},
+		{
+			name: "from only - rejects before",
+			from: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			ts:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			want: false,
+		},
+		{
+			name: "to only - matches before",
+			to:   time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC),
+			ts:   time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			want: true,
+		},
+		{
+			name: "to only - rejects after",
+			to:   time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			ts:   time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC),
+			want: false,
+		},
+		{
+			name: "range - matches within",
+			from: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			to:   time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC),
+			ts:   time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			want: true,
+		},
+		{
+			name: "range - rejects outside",
+			from: time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC),
+			to:   time.Date(2024, 1, 20, 0, 0, 0, 0, time.UTC),
+			ts:   time.Date(2024, 1, 25, 0, 0, 0, 0, time.UTC),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := NewDateFilter(tt.from, tt.to)
+			entry := &models.LogEntry{Timestamp: tt.ts}
+			if got := f.Matches(entry); got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseDateFlag(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantErr bool
+	}{
+		{"", false},
+		{"2024-01-15", false},
+		{"2024-01-15T10:30:00Z", false},
+		{"2024-01-15T10:30:00+01:00", false},
+		{"invalid", true},
+		{"2024/01/15", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			_, err := ParseDateFlag(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseDateFlag(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAnalyzer_SingleFile(t *testing.T) {
+	dir := setupTestData(t)
+
+	opts := &AnalyzerOptions{
+		Workers:    1,
+		ParserType: "nginx",
+	}
+	analyzer := NewAnalyzer(opts)
+
+	report, err := analyzer.Analyze(context.Background(), []string{filepath.Join(dir, "access.log")})
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+
+	if report.Summary.TotalFiles != 1 {
+		t.Errorf("TotalFiles = %d, want 1", report.Summary.TotalFiles)
+	}
+
+	if report.Summary.TotalEntries != 4 {
+		t.Errorf("TotalEntries = %d, want 4", report.Summary.TotalEntries)
+	}
+}
+
+func TestAnalyzer_MultipleFiles(t *testing.T) {
+	dir := setupTestData(t)
+
+	opts := &AnalyzerOptions{
+		Workers:    2,
+		ParserType: "nginx",
+	}
+	analyzer := NewAnalyzer(opts)
+
+	report, err := analyzer.Analyze(context.Background(), []string{filepath.Join(dir, "*.log")})
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+
+	if report.Summary.TotalFiles != 2 {
+		t.Errorf("TotalFiles = %d, want 2", report.Summary.TotalFiles)
+	}
+
+	if report.Summary.TotalEntries != 6 {
+		t.Errorf("TotalEntries = %d, want 6", report.Summary.TotalEntries)
+	}
+}
+
+func TestAnalyzer_DateFilter(t *testing.T) {
+	dir := setupTestData(t)
+
+	// Filter to only Jan 1
+	from, _ := ParseDateFlag("2024-01-01")
+	to, _ := ParseDateFlagEndOfDay("2024-01-01")
+
+	opts := &AnalyzerOptions{
+		Workers:    1,
+		ParserType: "nginx",
+		From:       from,
+		To:         to,
+	}
+	analyzer := NewAnalyzer(opts)
+
+	report, err := analyzer.Analyze(context.Background(), []string{filepath.Join(dir, "*.log")})
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+
+	// Only Jan 1 entries (4 from access.log, 0 from access2.log)
+	if report.Summary.TotalEntries != 4 {
+		t.Errorf("TotalEntries = %d, want 4", report.Summary.TotalEntries)
+	}
+}
+
+func TestAnalyzer_Limit(t *testing.T) {
+	dir := setupTestData(t)
+
+	opts := &AnalyzerOptions{
+		Workers:    1,
+		ParserType: "nginx",
+		Limit:      2,
+	}
+	analyzer := NewAnalyzer(opts)
+
+	report, err := analyzer.Analyze(context.Background(), []string{filepath.Join(dir, "access.log")})
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+
+	if report.Summary.TotalEntries != 2 {
+		t.Errorf("TotalEntries = %d, want 2", report.Summary.TotalEntries)
+	}
+}
+
+func TestAnalyzer_ContextCancel(t *testing.T) {
+	dir := setupTestData(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	opts := &AnalyzerOptions{
+		Workers:    1,
+		ParserType: "nginx",
+	}
+	analyzer := NewAnalyzer(opts)
+
+	_, err := analyzer.Analyze(ctx, []string{filepath.Join(dir, "*.log")})
+	// Should complete without error even if cancelled
+	if err != nil {
+		t.Logf("Analyze() with cancelled context returned: %v", err)
+	}
+}
+
+func TestAnalyzer_NoMatchingFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	opts := DefaultOptions()
+	analyzer := NewAnalyzer(opts)
+
+	_, err := analyzer.Analyze(context.Background(), []string{filepath.Join(dir, "nonexistent*.log")})
+	if err == nil {
+		t.Error("expected error for no matching files")
+	}
+}
+
+func TestWorkerPool_Basic(t *testing.T) {
+	pool := NewWorkerPool(2, 10)
+
+	processed := make(chan string, 10)
+	processor := func(ctx context.Context, path string) (*FileStats, error) {
+		processed <- path
+		return NewFileStats(path), nil
+	}
+
+	ctx := context.Background()
+	pool.Start(ctx, processor)
+
+	pool.Submit(ctx, "file1")
+	pool.Submit(ctx, "file2")
+	pool.Submit(ctx, "file3")
+	pool.Close()
+
+	// Drain results
+	results := make([]*FileStats, 0)
+	for r := range pool.Results() {
+		results = append(results, r)
+	}
+
+	if len(results) != 3 {
+		t.Errorf("got %d results, want 3", len(results))
+	}
+}
+
+func TestExporter_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	exporter := NewExporter(ExportJSON, &buf)
+
+	report := &Report{
+		Duration: time.Second,
+		Summary:  NewSummary(),
+		Files:    []*FileStats{},
+	}
+	report.Summary.TotalFiles = 1
+	report.Summary.TotalEntries = 100
+
+	if err := exporter.ExportReport(report); err != nil {
+		t.Fatalf("ExportReport() error = %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Error("expected non-empty JSON output")
+	}
+
+	// Verify it's valid JSON
+	if !bytes.Contains(buf.Bytes(), []byte(`"total_files"`)) {
+		t.Error("JSON output missing expected field")
+	}
+}
+
+func TestExporter_CSV(t *testing.T) {
+	var buf bytes.Buffer
+	exporter := NewExporter(ExportCSV, &buf)
+
+	report := &Report{
+		Duration: time.Second,
+		Summary:  NewSummary(),
+		Files:    []*FileStats{NewFileStats("/test/file.log")},
+	}
+	report.Summary.TotalFiles = 1
+	report.Summary.TotalEntries = 100
+
+	if err := exporter.ExportReport(report); err != nil {
+		t.Fatalf("ExportReport() error = %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Error("expected non-empty CSV output")
+	}
+
+	// Check for summary section
+	if !bytes.Contains(buf.Bytes(), []byte("# Summary")) {
+		t.Error("CSV output missing Summary section")
+	}
+}
+
+func TestExporter_Entries(t *testing.T) {
+	var buf bytes.Buffer
+	exporter := NewExporter(ExportJSON, &buf)
+
+	entries := []*models.LogEntry{
+		{
+			Timestamp: time.Now(),
+			Level:     models.LevelInfo,
+			Message:   "test message",
+		},
+	}
+
+	if err := exporter.ExportEntries(entries); err != nil {
+		t.Fatalf("ExportEntries() error = %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Error("expected non-empty output")
+	}
+}
+
+func TestReport_Aggregation(t *testing.T) {
+	files := []*FileStats{
+		{
+			Path:        "/file1.log",
+			ParsedCount: 100,
+			ErrorCount:  10,
+			LevelCounts: map[string]int64{"info": 80, "error": 20},
+			TypeCounts:  map[string]int64{"nginx": 100},
+		},
+		{
+			Path:        "/file2.log",
+			ParsedCount: 50,
+			ErrorCount:  5,
+			LevelCounts: map[string]int64{"info": 40, "warning": 10},
+			TypeCounts:  map[string]int64{"apache": 50},
+		},
+	}
+
+	summary := Aggregate(files, time.Second)
+
+	if summary.TotalFiles != 2 {
+		t.Errorf("TotalFiles = %d, want 2", summary.TotalFiles)
+	}
+
+	if summary.TotalEntries != 150 {
+		t.Errorf("TotalEntries = %d, want 150", summary.TotalEntries)
+	}
+
+	if summary.TotalErrors != 15 {
+		t.Errorf("TotalErrors = %d, want 15", summary.TotalErrors)
+	}
+
+	if summary.LevelCounts["info"] != 120 {
+		t.Errorf("LevelCounts[info] = %d, want 120", summary.LevelCounts["info"])
+	}
+
+	if summary.EntriesPerSec != 150 {
+		t.Errorf("EntriesPerSec = %f, want 150", summary.EntriesPerSec)
+	}
+}
+
+func TestSummary_Percentages(t *testing.T) {
+	s := &Summary{
+		TotalEntries: 100,
+		LevelCounts:  map[string]int64{"info": 80, "error": 20},
+		TypeCounts:   map[string]int64{"nginx": 60, "apache": 40},
+	}
+
+	if pct := s.LevelPercentage("info"); pct != 80.0 {
+		t.Errorf("LevelPercentage(info) = %f, want 80.0", pct)
+	}
+
+	if pct := s.TypePercentage("nginx"); pct != 60.0 {
+		t.Errorf("TypePercentage(nginx) = %f, want 60.0", pct)
+	}
+}
+
+func TestExpandGlobs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create test files
+	for _, name := range []string{"a.log", "b.log", "c.txt"} {
+		f, _ := os.Create(filepath.Join(dir, name))
+		f.Close()
+	}
+
+	files := expandGlobs([]string{filepath.Join(dir, "*.log")})
+
+	if len(files) != 2 {
+		t.Errorf("got %d files, want 2", len(files))
+	}
+}

--- a/internal/batch/benchmark_test.go
+++ b/internal/batch/benchmark_test.go
@@ -1,0 +1,241 @@
+package batch
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+// generateNginxLog creates a test nginx log file with n lines
+func generateNginxLog(t testing.TB, dir string, name string, lines int) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	baseTime := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	for i := 0; i < lines; i++ {
+		ts := baseTime.Add(time.Duration(i) * time.Second)
+		ip := fmt.Sprintf("192.168.1.%d", (i%254)+1)
+		status := []int{200, 200, 200, 200, 201, 301, 404, 500}[i%8]
+		uri := []string{"/", "/index.html", "/api/users", "/api/products", "/about"}[i%5]
+
+		fmt.Fprintf(&buf, "%s - - [%s] \"GET %s HTTP/1.1\" %d %d \"-\" \"Mozilla/5.0\"\n",
+			ip,
+			ts.Format("02/Jan/2006:15:04:05 -0700"),
+			uri,
+			status,
+			1000+i,
+		)
+	}
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	return path
+}
+
+func BenchmarkAnalyze_SingleFile_1000Lines(b *testing.B) {
+	dir := b.TempDir()
+	path := generateNginxLog(b, dir, "test.log", 1000)
+
+	opts := &AnalyzerOptions{
+		Workers:    1,
+		ParserType: "nginx",
+	}
+	analyzer := NewAnalyzer(opts)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := analyzer.Analyze(context.Background(), []string{path})
+		if err != nil {
+			b.Fatalf("Analyze failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkAnalyze_SingleFile_10000Lines(b *testing.B) {
+	dir := b.TempDir()
+	path := generateNginxLog(b, dir, "test.log", 10000)
+
+	opts := &AnalyzerOptions{
+		Workers:    1,
+		ParserType: "nginx",
+	}
+	analyzer := NewAnalyzer(opts)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := analyzer.Analyze(context.Background(), []string{path})
+		if err != nil {
+			b.Fatalf("Analyze failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkAnalyze_Parallel_4Workers(b *testing.B) {
+	dir := b.TempDir()
+
+	// Create 8 files with 5000 lines each
+	patterns := make([]string, 8)
+	for i := 0; i < 8; i++ {
+		path := generateNginxLog(b, dir, fmt.Sprintf("test%d.log", i), 5000)
+		patterns[i] = path
+	}
+
+	opts := &AnalyzerOptions{
+		Workers:    4,
+		ParserType: "nginx",
+	}
+	analyzer := NewAnalyzer(opts)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := analyzer.Analyze(context.Background(), patterns)
+		if err != nil {
+			b.Fatalf("Analyze failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkAnalyze_Parallel_8Workers(b *testing.B) {
+	dir := b.TempDir()
+
+	// Create 8 files with 5000 lines each
+	patterns := make([]string, 8)
+	for i := 0; i < 8; i++ {
+		path := generateNginxLog(b, dir, fmt.Sprintf("test%d.log", i), 5000)
+		patterns[i] = path
+	}
+
+	opts := &AnalyzerOptions{
+		Workers:    8,
+		ParserType: "nginx",
+	}
+	analyzer := NewAnalyzer(opts)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := analyzer.Analyze(context.Background(), patterns)
+		if err != nil {
+			b.Fatalf("Analyze failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkDateFilter_Apply(b *testing.B) {
+	filter := NewDateFilter(
+		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC),
+	)
+
+	entries := make([]*models.LogEntry, 1000)
+	for i := range entries {
+		entries[i] = &models.LogEntry{
+			Timestamp: time.Date(2024, 1, 15, 10, i%60, i%60, 0, time.UTC),
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, e := range entries {
+			filter.Matches(e)
+		}
+	}
+}
+
+func BenchmarkWorkerPool_Throughput(b *testing.B) {
+	processor := func(ctx context.Context, path string) (*FileStats, error) {
+		return NewFileStats(path), nil
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pool := NewWorkerPool(4, 10)
+		ctx := context.Background()
+		pool.Start(ctx, processor)
+
+		// Submit 10 jobs per iteration
+		for j := 0; j < 10; j++ {
+			pool.Submit(ctx, fmt.Sprintf("/test/file%d.log", j))
+		}
+		pool.Close()
+
+		// Drain results
+		for range pool.Results() {
+		}
+	}
+}
+
+func BenchmarkExport_JSON_1000Entries(b *testing.B) {
+	entries := make([]*models.LogEntry, 1000)
+	for i := range entries {
+		entries[i] = &models.LogEntry{
+			Timestamp: time.Now(),
+			Level:     models.LevelInfo,
+			Type:      models.LogTypeNginx,
+			Message:   fmt.Sprintf("Test message %d", i),
+			Source:    "test",
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		exporter := NewExporter(ExportJSON, &buf)
+		exporter.ExportEntries(entries)
+	}
+}
+
+func BenchmarkExport_CSV_1000Entries(b *testing.B) {
+	entries := make([]*models.LogEntry, 1000)
+	for i := range entries {
+		entries[i] = &models.LogEntry{
+			Timestamp: time.Now(),
+			Level:     models.LevelInfo,
+			Type:      models.LogTypeNginx,
+			Message:   fmt.Sprintf("Test message %d", i),
+			Source:    "test",
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		exporter := NewExporter(ExportCSV, &buf)
+		exporter.ExportEntries(entries)
+	}
+}
+
+func BenchmarkAggregate_100Files(b *testing.B) {
+	files := make([]*FileStats, 100)
+	for i := range files {
+		files[i] = &FileStats{
+			Path:        fmt.Sprintf("/test/file%d.log", i),
+			ParsedCount: 10000,
+			ErrorCount:  100,
+			LevelCounts: map[string]int64{
+				"debug":   1000,
+				"info":    7000,
+				"warning": 1000,
+				"error":   900,
+				"fatal":   100,
+			},
+			TypeCounts: map[string]int64{
+				"nginx": 10000,
+			},
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Aggregate(files, time.Second)
+	}
+}

--- a/internal/batch/export.go
+++ b/internal/batch/export.go
@@ -1,0 +1,195 @@
+package batch
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+// ExportFormat defines the output format for exports.
+type ExportFormat string
+
+const (
+	ExportJSON ExportFormat = "json"
+	ExportCSV  ExportFormat = "csv"
+)
+
+// ParseExportFormat parses a string to ExportFormat.
+func ParseExportFormat(s string) (ExportFormat, bool) {
+	switch s {
+	case "json":
+		return ExportJSON, true
+	case "csv":
+		return ExportCSV, true
+	default:
+		return "", false
+	}
+}
+
+// Exporter handles report and entries export to various formats.
+type Exporter struct {
+	format ExportFormat
+	writer io.Writer
+}
+
+// NewExporter creates an exporter for the given format.
+func NewExporter(format ExportFormat, w io.Writer) *Exporter {
+	return &Exporter{
+		format: format,
+		writer: w,
+	}
+}
+
+// ExportReport writes the analysis report in the configured format.
+func (e *Exporter) ExportReport(report *Report) error {
+	switch e.format {
+	case ExportCSV:
+		return e.exportReportCSV(report)
+	default:
+		return e.exportReportJSON(report)
+	}
+}
+
+func (e *Exporter) exportReportJSON(report *Report) error {
+	encoder := json.NewEncoder(e.writer)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(report)
+}
+
+func (e *Exporter) exportReportCSV(report *Report) error {
+	w := csv.NewWriter(e.writer)
+	defer w.Flush()
+
+	// Summary header
+	w.Write([]string{"# Summary"})
+	w.Write([]string{"total_files", strconv.Itoa(report.Summary.TotalFiles)})
+	w.Write([]string{"total_entries", strconv.FormatInt(report.Summary.TotalEntries, 10)})
+	w.Write([]string{"total_errors", strconv.FormatInt(report.Summary.TotalErrors, 10)})
+	w.Write([]string{"parse_errors", strconv.FormatInt(report.Summary.ParseErrors, 10)})
+	w.Write([]string{"entries_per_sec", strconv.FormatFloat(report.Summary.EntriesPerSec, 'f', 2, 64)})
+	w.Write([]string{"duration_ms", strconv.FormatInt(report.Duration.Milliseconds(), 10)})
+	w.Write([]string{})
+
+	// Level counts
+	w.Write([]string{"# Level Counts"})
+	w.Write([]string{"level", "count"})
+	for level, count := range report.Summary.LevelCounts {
+		w.Write([]string{level, strconv.FormatInt(count, 10)})
+	}
+	w.Write([]string{})
+
+	// Type counts
+	w.Write([]string{"# Type Counts"})
+	w.Write([]string{"type", "count"})
+	for typ, count := range report.Summary.TypeCounts {
+		w.Write([]string{typ, strconv.FormatInt(count, 10)})
+	}
+	w.Write([]string{})
+
+	// File details
+	w.Write([]string{"# File Details"})
+	w.Write([]string{"path", "parsed", "errors", "parse_errors", "parse_time_ms"})
+	for _, f := range report.Files {
+		w.Write([]string{
+			f.Path,
+			strconv.FormatInt(f.ParsedCount, 10),
+			strconv.FormatInt(f.ErrorCount, 10),
+			strconv.FormatInt(f.ParseErrors, 10),
+			strconv.FormatInt(f.ParseTime.Milliseconds(), 10),
+		})
+	}
+
+	return w.Error()
+}
+
+// ExportEntries writes log entries in the configured format.
+func (e *Exporter) ExportEntries(entries []*models.LogEntry) error {
+	switch e.format {
+	case ExportCSV:
+		return e.exportEntriesCSV(entries)
+	default:
+		return e.exportEntriesJSON(entries)
+	}
+}
+
+func (e *Exporter) exportEntriesJSON(entries []*models.LogEntry) error {
+	encoder := json.NewEncoder(e.writer)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(entries)
+}
+
+func (e *Exporter) exportEntriesCSV(entries []*models.LogEntry) error {
+	w := csv.NewWriter(e.writer)
+	defer w.Flush()
+
+	// Header
+	w.Write([]string{"timestamp", "level", "type", "source", "message", "file_path", "line_number"})
+
+	// Rows
+	for _, entry := range entries {
+		w.Write([]string{
+			entry.Timestamp.Format(time.RFC3339),
+			string(entry.Level),
+			string(entry.Type),
+			entry.Source,
+			entry.Message,
+			entry.FilePath,
+			strconv.FormatInt(entry.LineNumber, 10),
+		})
+	}
+
+	return w.Error()
+}
+
+// ExportEntriesStream writes log entries from a channel.
+func (e *Exporter) ExportEntriesStream(entries <-chan *models.LogEntry) error {
+	switch e.format {
+	case ExportCSV:
+		return e.exportEntriesStreamCSV(entries)
+	default:
+		return e.exportEntriesStreamJSON(entries)
+	}
+}
+
+func (e *Exporter) exportEntriesStreamJSON(entries <-chan *models.LogEntry) error {
+	encoder := json.NewEncoder(e.writer)
+	e.writer.Write([]byte("[\n"))
+	first := true
+	for entry := range entries {
+		if !first {
+			e.writer.Write([]byte(",\n"))
+		}
+		first = false
+		if err := encoder.Encode(entry); err != nil {
+			return err
+		}
+	}
+	e.writer.Write([]byte("\n]\n"))
+	return nil
+}
+
+func (e *Exporter) exportEntriesStreamCSV(entries <-chan *models.LogEntry) error {
+	w := csv.NewWriter(e.writer)
+	defer w.Flush()
+
+	// Header
+	w.Write([]string{"timestamp", "level", "type", "source", "message", "file_path", "line_number"})
+
+	for entry := range entries {
+		w.Write([]string{
+			entry.Timestamp.Format(time.RFC3339),
+			string(entry.Level),
+			string(entry.Type),
+			entry.Source,
+			entry.Message,
+			entry.FilePath,
+			strconv.FormatInt(entry.LineNumber, 10),
+		})
+	}
+
+	return w.Error()
+}

--- a/internal/batch/filter.go
+++ b/internal/batch/filter.go
@@ -1,0 +1,104 @@
+package batch
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/good-yellow-bee/blazelog/internal/models"
+)
+
+// DateFilter filters log entries by date range.
+type DateFilter struct {
+	From    time.Time
+	To      time.Time
+	Enabled bool
+}
+
+// NewDateFilter creates a filter from parsed from/to times.
+// If both are zero, filter is disabled.
+func NewDateFilter(from, to time.Time) *DateFilter {
+	return &DateFilter{
+		From:    from,
+		To:      to,
+		Enabled: !from.IsZero() || !to.IsZero(),
+	}
+}
+
+// Matches returns true if entry timestamp is within the date range.
+// If filter is disabled, always returns true.
+func (f *DateFilter) Matches(entry *models.LogEntry) bool {
+	if !f.Enabled {
+		return true
+	}
+
+	ts := entry.Timestamp
+
+	// Check from bound (inclusive)
+	if !f.From.IsZero() && ts.Before(f.From) {
+		return false
+	}
+
+	// Check to bound (inclusive - we use end of day)
+	if !f.To.IsZero() && ts.After(f.To) {
+		return false
+	}
+
+	return true
+}
+
+// MatchesTime checks if a timestamp is within the date range.
+func (f *DateFilter) MatchesTime(ts time.Time) bool {
+	if !f.Enabled {
+		return true
+	}
+
+	if !f.From.IsZero() && ts.Before(f.From) {
+		return false
+	}
+
+	if !f.To.IsZero() && ts.After(f.To) {
+		return false
+	}
+
+	return true
+}
+
+// ParseDateFlag parses a date string in YYYY-MM-DD or RFC3339 format.
+// For YYYY-MM-DD, it returns start of day in local timezone.
+func ParseDateFlag(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+
+	// Try RFC3339 first
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+
+	// Try date-only format (YYYY-MM-DD)
+	if t, err := time.ParseInLocation("2006-01-02", s, time.Local); err == nil {
+		return t, nil
+	}
+
+	return time.Time{}, fmt.Errorf("invalid date format: %q (expected YYYY-MM-DD or RFC3339)", s)
+}
+
+// ParseDateFlagEndOfDay parses a date string and returns end of day for YYYY-MM-DD format.
+// For RFC3339, returns the exact time. For YYYY-MM-DD, returns 23:59:59.999999999.
+func ParseDateFlagEndOfDay(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+
+	// Try RFC3339 first - return exact time
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+
+	// Try date-only format - return end of day
+	if t, err := time.ParseInLocation("2006-01-02", s, time.Local); err == nil {
+		return t.Add(24*time.Hour - time.Nanosecond), nil
+	}
+
+	return time.Time{}, fmt.Errorf("invalid date format: %q (expected YYYY-MM-DD or RFC3339)", s)
+}

--- a/internal/batch/report.go
+++ b/internal/batch/report.go
@@ -1,0 +1,112 @@
+package batch
+
+import (
+	"time"
+)
+
+// Report contains complete batch analysis results.
+type Report struct {
+	StartTime time.Time      `json:"start_time"`
+	EndTime   time.Time      `json:"end_time"`
+	Duration  time.Duration  `json:"duration_ms"`
+	Files     []*FileStats   `json:"files"`
+	Summary   *Summary       `json:"summary"`
+	DateRange *DateRange     `json:"date_range,omitempty"`
+	Errors    []string       `json:"errors,omitempty"`
+}
+
+// FileStats contains per-file statistics.
+type FileStats struct {
+	Path        string           `json:"path"`
+	ParsedCount int64            `json:"parsed_count"`
+	ErrorCount  int64            `json:"error_count"`
+	ParseErrors int64            `json:"parse_errors"`
+	LevelCounts map[string]int64 `json:"level_counts"`
+	TypeCounts  map[string]int64 `json:"type_counts"`
+	FirstEntry  time.Time        `json:"first_entry,omitempty"`
+	LastEntry   time.Time        `json:"last_entry,omitempty"`
+	BytesRead   int64            `json:"bytes_read"`
+	ParseTime   time.Duration    `json:"parse_time_ms"`
+}
+
+// NewFileStats creates a new FileStats with initialized maps.
+func NewFileStats(path string) *FileStats {
+	return &FileStats{
+		Path:        path,
+		LevelCounts: make(map[string]int64),
+		TypeCounts:  make(map[string]int64),
+	}
+}
+
+// Summary aggregates statistics across all files.
+type Summary struct {
+	TotalFiles    int              `json:"total_files"`
+	TotalEntries  int64            `json:"total_entries"`
+	TotalErrors   int64            `json:"total_errors"`
+	ParseErrors   int64            `json:"parse_errors"`
+	LevelCounts   map[string]int64 `json:"level_counts"`
+	TypeCounts    map[string]int64 `json:"type_counts"`
+	SourceCounts  map[string]int64 `json:"source_counts"`
+	EntriesPerSec float64          `json:"entries_per_sec"`
+}
+
+// NewSummary creates a new Summary with initialized maps.
+func NewSummary() *Summary {
+	return &Summary{
+		LevelCounts:  make(map[string]int64),
+		TypeCounts:   make(map[string]int64),
+		SourceCounts: make(map[string]int64),
+	}
+}
+
+// DateRange tracks the actual date range of analyzed entries.
+type DateRange struct {
+	Earliest time.Time `json:"earliest,omitempty"`
+	Latest   time.Time `json:"latest,omitempty"`
+	Filtered bool      `json:"filtered"`
+	From     time.Time `json:"from,omitempty"`
+	To       time.Time `json:"to,omitempty"`
+}
+
+// Aggregate combines multiple FileStats into a Summary.
+func Aggregate(files []*FileStats, duration time.Duration) *Summary {
+	s := NewSummary()
+	s.TotalFiles = len(files)
+
+	for _, f := range files {
+		s.TotalEntries += f.ParsedCount
+		s.TotalErrors += f.ErrorCount
+		s.ParseErrors += f.ParseErrors
+		s.SourceCounts[f.Path] = f.ParsedCount
+
+		for level, count := range f.LevelCounts {
+			s.LevelCounts[level] += count
+		}
+
+		for typ, count := range f.TypeCounts {
+			s.TypeCounts[typ] += count
+		}
+	}
+
+	if duration.Seconds() > 0 {
+		s.EntriesPerSec = float64(s.TotalEntries) / duration.Seconds()
+	}
+
+	return s
+}
+
+// LevelPercentage returns the percentage for a given level.
+func (s *Summary) LevelPercentage(level string) float64 {
+	if s.TotalEntries == 0 {
+		return 0
+	}
+	return float64(s.LevelCounts[level]) / float64(s.TotalEntries) * 100
+}
+
+// TypePercentage returns the percentage for a given type.
+func (s *Summary) TypePercentage(typ string) float64 {
+	if s.TotalEntries == 0 {
+		return 0
+	}
+	return float64(s.TypeCounts[typ]) / float64(s.TotalEntries) * 100
+}

--- a/internal/batch/worker.go
+++ b/internal/batch/worker.go
@@ -1,0 +1,116 @@
+package batch
+
+import (
+	"context"
+	"runtime"
+	"sync"
+)
+
+// WorkerPool manages parallel file processing.
+type WorkerPool struct {
+	workers    int
+	bufferSize int
+	jobs       chan string
+	results    chan *FileStats
+	errors     chan error
+	wg         sync.WaitGroup
+	started    bool
+	mu         sync.Mutex
+}
+
+// NewWorkerPool creates a pool with N workers.
+// If workers <= 0, defaults to runtime.NumCPU().
+func NewWorkerPool(workers, bufferSize int) *WorkerPool {
+	if workers <= 0 {
+		workers = runtime.NumCPU()
+	}
+	if bufferSize <= 0 {
+		bufferSize = workers * 2
+	}
+
+	return &WorkerPool{
+		workers:    workers,
+		bufferSize: bufferSize,
+		jobs:       make(chan string, bufferSize),
+		results:    make(chan *FileStats, bufferSize),
+		errors:     make(chan error, bufferSize),
+	}
+}
+
+// Start begins worker goroutines with the given processor function.
+// The processor receives a file path and returns stats or error.
+func (p *WorkerPool) Start(ctx context.Context, processor func(context.Context, string) (*FileStats, error)) {
+	p.mu.Lock()
+	if p.started {
+		p.mu.Unlock()
+		return
+	}
+	p.started = true
+	p.mu.Unlock()
+
+	for i := 0; i < p.workers; i++ {
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case path, ok := <-p.jobs:
+					if !ok {
+						return
+					}
+					stats, err := processor(ctx, path)
+					if err != nil {
+						select {
+						case p.errors <- err:
+						case <-ctx.Done():
+							return
+						}
+						continue
+					}
+					select {
+					case p.results <- stats:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+		}()
+	}
+}
+
+// Submit adds a file path to the job queue.
+// Returns error if pool is closed or context cancelled.
+func (p *WorkerPool) Submit(ctx context.Context, path string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case p.jobs <- path:
+		return nil
+	}
+}
+
+// Close signals no more jobs and waits for completion.
+// Closes results and errors channels after all workers finish.
+func (p *WorkerPool) Close() {
+	close(p.jobs)
+	p.wg.Wait()
+	close(p.results)
+	close(p.errors)
+}
+
+// Results returns the results channel.
+func (p *WorkerPool) Results() <-chan *FileStats {
+	return p.results
+}
+
+// Errors returns the errors channel.
+func (p *WorkerPool) Errors() <-chan error {
+	return p.errors
+}
+
+// Workers returns the number of workers.
+func (p *WorkerPool) Workers() int {
+	return p.workers
+}


### PR DESCRIPTION
## Summary
- Add `internal/batch` package with parallel file analysis
- Implement date range filtering (`--from`/`--to` flags)
- Add worker pool for concurrent file processing
- Support CSV/JSON export (`--export`/`--export-to` flags)
- Generate summary reports with level/type statistics
- Add 16 unit tests and 9 performance benchmarks

## Usage
```bash
# Basic analysis
blazelog analyze /var/log/*.log

# With date range filter
blazelog analyze /var/log/*.log --from 2024-01-01 --to 2024-01-31

# Parallel processing
blazelog analyze /var/log/*.log --workers 8

# Export to CSV
blazelog analyze /var/log/*.log --export csv --export-to report.csv
```

## Test plan
- [x] Unit tests pass (16 tests)
- [x] Benchmarks run successfully (9 benchmarks)
- [x] Full test suite passes
- [x] CLI tested with real log files

Closes #29