### PR TITLE
31 - Docker Development & Production Environment

### DIFF
--- a/deployments/docker/Dockerfile.agent
+++ b/deployments/docker/Dockerfile.agent
@@ -26,8 +26,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
 # Runtime stage - Alpine for filesystem access (needed for log collection)
 FROM alpine:3.21
 
-# Install ca-certificates and tzdata
-RUN apk add --no-cache ca-certificates tzdata \
+# Install ca-certificates, tzdata, and netcat for health checks
+RUN apk add --no-cache ca-certificates tzdata netcat-openbsd \
     && addgroup -g 1000 blazelog \
     && adduser -u 1000 -G blazelog -s /bin/sh -D blazelog
 
@@ -37,14 +37,22 @@ COPY --from=builder /blazelog-agent /usr/local/bin/blazelog-agent
 # Copy default config
 COPY --from=builder /build/configs/agent.yaml /etc/blazelog/agent.yaml
 
+# Copy entrypoint script
+COPY deployments/docker/scripts/agent-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 # Config volume
 VOLUME /etc/blazelog
 
 # Log directory mount point
 VOLUME /var/log
 
+# Data directory for agent state
+RUN mkdir -p /var/lib/blazelog && chown blazelog:blazelog /var/lib/blazelog
+VOLUME /var/lib/blazelog
+
 # Run as non-root user
 USER blazelog
 
-ENTRYPOINT ["blazelog-agent"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["-c", "/etc/blazelog/agent.yaml"]

--- a/deployments/docker/Dockerfile.server
+++ b/deployments/docker/Dockerfile.server
@@ -41,14 +41,23 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
         -X github.com/good-yellow-bee/blazelog/pkg/config.BuildTime=${BUILD_TIME}" \
     -o /blazelog-server ./cmd/server
 
-# Runtime stage - distroless for minimal attack surface
-FROM gcr.io/distroless/static-debian12:nonroot
+# Runtime stage - Alpine for better volume support
+FROM alpine:3.21
+
+# Install ca-certificates and create user
+RUN apk add --no-cache ca-certificates tzdata \
+    && addgroup -g 65532 nonroot \
+    && adduser -u 65532 -G nonroot -s /sbin/nologin -D nonroot
 
 # Copy binary
 COPY --from=builder /blazelog-server /blazelog-server
 
 # Copy default config
 COPY --from=builder /build/configs/server.yaml /etc/blazelog/server.yaml
+
+# Create data directory with correct permissions
+RUN mkdir -p /data /etc/blazelog/certs /var/log/blazelog \
+    && chown -R nonroot:nonroot /data /etc/blazelog /var/log/blazelog
 
 # Data and config volumes
 VOLUME /data

--- a/deployments/docker/config/agent.yaml
+++ b/deployments/docker/config/agent.yaml
@@ -1,0 +1,49 @@
+# BlazeLog Agent Configuration for Docker
+#
+# This config is optimized for containerized deployment.
+# Mount log directories as volumes to collect logs.
+
+# Server connection settings
+server:
+  # BlazeLog server address (Docker service name)
+  address: "server:9443"
+
+  # TLS configuration for mTLS (mutual TLS)
+  # Uncomment to enable secure communication
+  tls:
+    enabled: false
+    # cert_file: "/etc/blazelog/certs/agent.crt"
+    # key_file: "/etc/blazelog/certs/agent.key"
+    # ca_file: "/etc/blazelog/certs/ca.crt"
+
+# Agent settings
+agent:
+  # Agent name (defaults to container hostname)
+  name: ""
+  batch_size: 100
+  flush_interval: 1s
+
+# Log sources to collect
+# Mount the log directories as volumes in docker-compose
+sources:
+  # Example: Nginx logs (mount /var/log/nginx to container)
+  - name: "nginx-access"
+    type: "nginx"
+    path: "/var/log/nginx/access.log"
+    follow: true
+
+  - name: "nginx-error"
+    type: "nginx"
+    path: "/var/log/nginx/error.log"
+    follow: true
+
+  # Add more sources as needed
+  # - name: "app-logs"
+  #   type: "auto"
+  #   path: "/var/log/app/*.log"
+  #   follow: true
+
+# Labels for categorization
+labels:
+  environment: "docker"
+  project: "blazelog"

--- a/deployments/docker/config/known_hosts
+++ b/deployments/docker/config/known_hosts
@@ -1,0 +1,8 @@
+# SSH Known Hosts File
+# Add trusted host keys here for SSH log collection
+#
+# Format: hostname/IP algorithm public_key
+# Example: server.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI...
+#
+# To add a host key:
+#   ssh-keyscan -t ed25519 server.example.com >> known_hosts

--- a/deployments/docker/config/server-prod.yaml
+++ b/deployments/docker/config/server-prod.yaml
@@ -1,0 +1,59 @@
+# BlazeLog Server Configuration for Docker Production
+#
+# This config enables ClickHouse for log storage.
+# Use with: docker compose --profile prod up -d
+
+server:
+  grpc_address: ":9443"
+  http_address: ":8080"
+
+  # Enable mTLS for production
+  tls:
+    enabled: false
+    # Uncomment and configure for mTLS:
+    # cert_file: "/etc/blazelog/certs/server.crt"
+    # key_file: "/etc/blazelog/certs/server.key"
+    # client_ca_file: "/etc/blazelog/certs/ca.crt"
+
+# Database configuration
+database:
+  path: "/data/blazelog.db"
+
+# Authentication configuration
+auth:
+  jwt_secret_env: "BLAZELOG_JWT_SECRET"
+  csrf_secret_env: "BLAZELOG_CSRF_SECRET"
+  access_token_ttl: "15m"
+  refresh_token_ttl: "168h"  # 7 days
+  rate_limit_per_ip: 100
+  rate_limit_per_user: 1000
+  lockout_threshold: 5
+  lockout_duration: "15m"
+
+# SSH security settings
+ssh:
+  host_key_file: "/etc/blazelog/known_hosts"
+  host_key_policy: "strict"
+  audit_log: "/data/ssh-audit.log"
+  pool:
+    max_per_host: 5
+    idle_timeout: 5m
+
+# Metrics configuration
+metrics:
+  enabled: true
+  address: ":9090"
+
+# ClickHouse configuration - ENABLED for production
+clickhouse:
+  enabled: true
+  addresses:
+    - "clickhouse:9000"
+  database: "blazelog"
+  username: "blazelog"
+  password_env: "CLICKHOUSE_PASSWORD"
+  batch_size: 10000
+  flush_interval: "5s"
+  max_buffer_size: 100000
+  max_open_conns: 10
+  retention_days: 90

--- a/deployments/docker/config/server.yaml
+++ b/deployments/docker/config/server.yaml
@@ -1,0 +1,65 @@
+# BlazeLog Server Configuration for Docker
+#
+# This config is optimized for containerized deployment.
+# Environment variables are used for secrets (see .env.example).
+
+server:
+  # gRPC listen address for agent connections
+  grpc_address: ":9443"
+
+  # HTTP listen address for REST API and Web UI
+  http_address: ":8080"
+
+  # TLS configuration for mTLS (mutual TLS)
+  # Uncomment to enable secure agent communication
+  tls:
+    enabled: false
+    # cert_file: "/etc/blazelog/certs/server.crt"
+    # key_file: "/etc/blazelog/certs/server.key"
+    # client_ca_file: "/etc/blazelog/certs/ca.crt"
+
+# Database configuration
+# SQLite database stored in /data volume
+database:
+  path: "/data/blazelog.db"
+
+# Authentication configuration
+# Secrets are loaded from environment variables
+auth:
+  jwt_secret_env: "BLAZELOG_JWT_SECRET"
+  csrf_secret_env: "BLAZELOG_CSRF_SECRET"
+  access_token_ttl: "15m"
+  refresh_token_ttl: "168h"  # 7 days
+  rate_limit_per_ip: 100
+  rate_limit_per_user: 1000
+  lockout_threshold: 5
+  lockout_duration: "15m"
+
+# SSH security settings (for agentless log collection)
+ssh:
+  host_key_file: "/etc/blazelog/known_hosts"
+  host_key_policy: "tofu"
+  audit_log: "/data/ssh-audit.log"
+  pool:
+    max_per_host: 5
+    idle_timeout: 5m
+
+# Metrics configuration
+metrics:
+  enabled: true
+  address: ":9090"
+
+# ClickHouse configuration (for prod profile)
+# Enable when using --profile prod
+clickhouse:
+  enabled: false
+  addresses:
+    - "clickhouse:9000"
+  database: "blazelog"
+  username: "blazelog"
+  password_env: "CLICKHOUSE_PASSWORD"
+  batch_size: 10000
+  flush_interval: "5s"
+  max_buffer_size: 100000
+  max_open_conns: 10
+  retention_days: 30

--- a/deployments/docker/docker-compose.override.yml
+++ b/deployments/docker/docker-compose.override.yml
@@ -1,0 +1,50 @@
+# Docker Compose Override for Local Development
+#
+# This file is automatically loaded by docker compose.
+# It adds development-specific configurations.
+#
+# To disable: rename or delete this file
+# To use production settings only: docker compose -f docker-compose.yml up
+
+services:
+  server:
+    # Use local build instead of pulling image
+    build:
+      context: ../..
+      dockerfile: deployments/docker/Dockerfile.server
+    # Mount local config for easy editing (override read-only)
+    volumes:
+      - blazelog-data:/data
+      - ./config/server.yaml:/etc/blazelog/server.yaml:rw
+      - blazelog-certs:/etc/blazelog/certs:ro
+      - blazelog-ssh:/etc/blazelog/ssh:ro
+      - ./config/known_hosts:/etc/blazelog/known_hosts:rw
+    # Enable verbose logging
+    command: ["-c", "/etc/blazelog/server.yaml", "-v"]
+    # Faster health check for dev
+    healthcheck:
+      interval: 10s
+      start_period: 5s
+
+  # Development-only: ClickHouse for local testing
+  # Uncomment to enable ClickHouse in dev mode
+  # clickhouse-dev:
+  #   image: clickhouse/clickhouse-server:24.3
+  #   container_name: blazelog-clickhouse-dev
+  #   ports:
+  #     - "9000:9000"
+  #     - "8123:8123"
+  #   environment:
+  #     - CLICKHOUSE_DB=blazelog
+  #     - CLICKHOUSE_USER=blazelog
+  #     - CLICKHOUSE_PASSWORD=devpassword
+  #   volumes:
+  #     - clickhouse-dev-data:/var/lib/clickhouse
+  #   networks:
+  #     - blazelog
+  #   profiles:
+  #     - dev
+
+# volumes:
+#   clickhouse-dev-data:
+#     name: blazelog-clickhouse-dev-data

--- a/deployments/docker/docker-compose.prod.yml
+++ b/deployments/docker/docker-compose.prod.yml
@@ -1,0 +1,80 @@
+# Docker Compose Production Overrides
+#
+# Use with: docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile prod up -d
+#
+# This file contains production-specific settings:
+# - ClickHouse-enabled server config
+# - Resource limits
+# - Log rotation
+# - Security hardening
+
+services:
+  server:
+    # Use production config with ClickHouse enabled
+    volumes:
+      - blazelog-data:/data
+      - ./config/server-prod.yaml:/etc/blazelog/server.yaml:ro
+      - blazelog-certs:/etc/blazelog/certs:ro
+      - blazelog-ssh:/etc/blazelog/ssh:ro
+      - ./config/known_hosts:/etc/blazelog/known_hosts:ro
+    # Resource limits
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 2G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+    # Production logging
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "5"
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+
+  clickhouse:
+    # Resource limits for ClickHouse
+    deploy:
+      resources:
+        limits:
+          cpus: '4'
+          memory: 8G
+        reservations:
+          cpus: '1'
+          memory: 2G
+    # Production logging
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "5"
+    # ClickHouse settings for production
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+
+  agent:
+    # Wait for server to be ready
+    environment:
+      - BLAZELOG_SERVER_ADDRESS=server:9443
+      - BLAZELOG_WAIT_FOR_SERVER=1
+    # Resource limits
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
+    # Production logging
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -1,4 +1,17 @@
-version: "3.9"
+# BlazeLog Docker Compose Configuration
+#
+# Profiles:
+#   dev  - Server only with SQLite (for development)
+#   prod - Full stack with ClickHouse (for production)
+#
+# Usage:
+#   docker compose --profile dev up -d     # Development
+#   docker compose --profile prod up -d    # Production
+#
+# Required environment variables (see .env.example):
+#   BLAZELOG_MASTER_KEY  - Encryption key for sensitive data
+#   BLAZELOG_JWT_SECRET  - JWT signing secret
+#   CLICKHOUSE_PASSWORD  - ClickHouse password (prod only)
 
 services:
   server:
@@ -12,23 +25,31 @@ services:
     image: blazelog/server:${VERSION:-latest}
     container_name: blazelog-server
     ports:
-      - "8080:8080"   # HTTP API / Web UI
-      - "9443:9443"   # gRPC (agents)
-      - "9090:9090"   # Prometheus metrics
+      - "${BLAZELOG_HTTP_PORT:-8080}:8080"   # HTTP API / Web UI
+      - "${BLAZELOG_GRPC_PORT:-9443}:9443"   # gRPC (agents)
+      - "${BLAZELOG_METRICS_PORT:-9090}:9090" # Prometheus metrics
     environment:
       - BLAZELOG_MASTER_KEY=${BLAZELOG_MASTER_KEY:?required}
       - BLAZELOG_JWT_SECRET=${BLAZELOG_JWT_SECRET:?required}
       - BLAZELOG_CSRF_SECRET=${BLAZELOG_CSRF_SECRET:-}
       - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:-}
     volumes:
+      # Data persistence (SQLite database)
       - blazelog-data:/data
+      # Configuration
       - ./config/server.yaml:/etc/blazelog/server.yaml:ro
+      # mTLS certificates (optional)
+      - blazelog-certs:/etc/blazelog/certs:ro
+      # SSH keys for agentless collection (optional)
+      - blazelog-ssh:/etc/blazelog/ssh:ro
+      # SSH known_hosts
+      - ./config/known_hosts:/etc/blazelog/known_hosts:ro
     healthcheck:
-      test: ["CMD", "/blazelog-server", "-c", "/etc/blazelog/server.yaml", "version"]
+      test: ["CMD", "/blazelog-server", "health", "--url", "http://localhost:8080/health/ready"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 10s
+      start_period: 15s
     restart: unless-stopped
     networks:
       - blazelog
@@ -40,12 +61,13 @@ services:
     image: clickhouse/clickhouse-server:24.3
     container_name: blazelog-clickhouse
     ports:
-      - "9000:9000"   # Native protocol
-      - "8123:8123"   # HTTP interface
+      - "${CLICKHOUSE_NATIVE_PORT:-9000}:9000"   # Native protocol
+      - "${CLICKHOUSE_HTTP_PORT:-8123}:8123"     # HTTP interface
     environment:
       - CLICKHOUSE_DB=blazelog
       - CLICKHOUSE_USER=blazelog
       - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:?required for prod}
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
     volumes:
       - clickhouse-data:/var/lib/clickhouse
       - clickhouse-logs:/var/log/clickhouse-server
@@ -54,6 +76,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 30s
     restart: unless-stopped
     networks:
       - blazelog
@@ -73,7 +96,11 @@ services:
     environment:
       - BLAZELOG_SERVER_ADDRESS=server:9443
     volumes:
+      # Configuration
       - ./config/agent.yaml:/etc/blazelog/agent.yaml:ro
+      # mTLS certificates (optional)
+      - blazelog-certs:/etc/blazelog/certs:ro
+      # Log directories to monitor (read-only)
       - /var/log:/var/log:ro
     depends_on:
       server:
@@ -87,6 +114,10 @@ services:
 volumes:
   blazelog-data:
     name: blazelog-data
+  blazelog-certs:
+    name: blazelog-certs
+  blazelog-ssh:
+    name: blazelog-ssh
   clickhouse-data:
     name: blazelog-clickhouse-data
   clickhouse-logs:

--- a/deployments/docker/scripts/agent-entrypoint.sh
+++ b/deployments/docker/scripts/agent-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# BlazeLog Agent Docker Entrypoint
+#
+# This script handles agent initialization before starting the main process.
+
+set -e
+
+# Wait for server to be ready (optional)
+if [ -n "$BLAZELOG_WAIT_FOR_SERVER" ]; then
+    echo "Waiting for server at $BLAZELOG_SERVER_ADDRESS..."
+
+    # Extract host and port from address
+    HOST=$(echo "$BLAZELOG_SERVER_ADDRESS" | cut -d: -f1)
+    PORT=$(echo "$BLAZELOG_SERVER_ADDRESS" | cut -d: -f2)
+
+    # Wait up to 60 seconds
+    for i in $(seq 1 60); do
+        if nc -z "$HOST" "$PORT" 2>/dev/null; then
+            echo "Server is ready!"
+            break
+        fi
+        if [ $i -eq 60 ]; then
+            echo "Timeout waiting for server"
+            exit 1
+        fi
+        sleep 1
+    done
+fi
+
+# Set agent name from hostname if not specified
+if [ -z "$BLAZELOG_AGENT_NAME" ]; then
+    export BLAZELOG_AGENT_NAME=$(hostname)
+fi
+
+# Create directories if needed
+mkdir -p /var/lib/blazelog 2>/dev/null || true
+
+echo "Starting BlazeLog Agent..."
+exec blazelog-agent "$@"


### PR DESCRIPTION
## Summary
- Add `health` subcommand to server binary for Docker/k8s health probes
- Switch server Dockerfile from distroless to Alpine for proper volume permissions
- Add agent entrypoint script with optional server wait capability
- Create dev (SQLite) and prod (ClickHouse) server configurations
- Add docker-compose profiles for dev and prod deployments
- Add mTLS certificate and SSH key volume mounts
- Create comprehensive .env.example template
- Add docker-compose.override.yml for dev and docker-compose.prod.yml for production
- Update DEPLOYMENT.md with detailed Docker deployment documentation

## Test plan
- [x] Verify Go code compiles with new health command
- [x] Validate docker-compose config for dev profile
- [x] Validate docker-compose config for prod profile
- [x] Build Docker images successfully
- [x] Start dev profile and verify server is healthy
- [x] Test /health endpoint returns 200
- [x] Test /health/ready endpoint returns status with checks