### PR TITLE
32 - Kubernetes Deployment

### DIFF
--- a/deployments/kubernetes/README.md
+++ b/deployments/kubernetes/README.md
@@ -1,0 +1,337 @@
+# BlazeLog Kubernetes Deployment
+
+Deploy BlazeLog to Kubernetes with a single command.
+
+## Quick Start
+
+```bash
+# 1. Create namespace and secrets
+kubectl create namespace blazelog
+
+# Generate and create secrets
+MASTER_KEY=$(openssl rand -base64 32)
+JWT_SECRET=$(openssl rand -base64 32)
+CSRF_SECRET=$(openssl rand -base64 32)
+CLICKHOUSE_PASSWORD=$(openssl rand -base64 16)
+
+kubectl create secret generic blazelog-secrets \
+  --namespace=blazelog \
+  --from-literal=master-key="$MASTER_KEY" \
+  --from-literal=jwt-secret="$JWT_SECRET" \
+  --from-literal=csrf-secret="$CSRF_SECRET" \
+  --from-literal=clickhouse-password="$CLICKHOUSE_PASSWORD"
+
+# 2. Deploy (choose one)
+kubectl apply -k deployments/kubernetes/base              # Basic
+kubectl apply -k deployments/kubernetes/overlays/dev      # Development
+kubectl apply -k deployments/kubernetes/overlays/prod     # Production
+
+# 3. Access UI
+kubectl port-forward -n blazelog svc/blazelog-server 8080:8080
+# Open http://localhost:8080
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         KUBERNETES CLUSTER                       │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                   │
+│  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐        │
+│  │   Node 1    │     │   Node 2    │     │   Node 3    │        │
+│  │ ┌─────────┐ │     │ ┌─────────┐ │     │ ┌─────────┐ │        │
+│  │ │ Agent   │ │     │ │ Agent   │ │     │ │ Agent   │ │        │
+│  │ │DaemonSet│ │     │ │DaemonSet│ │     │ │DaemonSet│ │        │
+│  │ └────┬────┘ │     │ └────┬────┘ │     │ └────┬────┘ │        │
+│  └──────┼──────┘     └──────┼──────┘     └──────┼──────┘        │
+│         │                   │                   │                │
+│         └───────────────────┼───────────────────┘                │
+│                             │ gRPC (9443)                        │
+│                             ▼                                    │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │                    blazelog-server                        │   │
+│  │  ┌────────────────┐  ┌────────────────┐                  │   │
+│  │  │   Deployment   │  │    Service     │                  │   │
+│  │  │   (1 replica)  │  │  (ClusterIP)   │                  │   │
+│  │  └───────┬────────┘  └────────────────┘                  │   │
+│  │          │                                                │   │
+│  │          │ Port 9000                                      │   │
+│  │          ▼                                                │   │
+│  │  ┌────────────────┐  ┌────────────────┐                  │   │
+│  │  │   ClickHouse   │  │      PVC       │                  │   │
+│  │  │  StatefulSet   │  │   (100Gi)      │                  │   │
+│  │  └────────────────┘  └────────────────┘                  │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                             │                                    │
+│                             │ HTTP (8080)                        │
+│                             ▼                                    │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │                       Ingress                             │   │
+│  │              blazelog.example.com                         │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Directory Structure
+
+```
+deployments/kubernetes/
+├── base/                      # Base manifests
+│   ├── kustomization.yaml     # Kustomize config
+│   ├── namespace.yaml         # Namespace definition
+│   ├── secrets.yaml           # Secret templates
+│   ├── pvc.yaml               # PersistentVolumeClaims
+│   ├── server-configmap.yaml  # Server configuration
+│   ├── server-deployment.yaml # Server Deployment
+│   ├── server-service.yaml    # Server Services
+│   ├── agent-configmap.yaml   # Agent configuration
+│   ├── agent-daemonset.yaml   # Agent DaemonSet
+│   ├── clickhouse-statefulset.yaml  # ClickHouse StatefulSet
+│   ├── clickhouse-service.yaml      # ClickHouse Services
+│   ├── ingress.yaml           # Ingress rules
+│   └── networkpolicy.yaml     # NetworkPolicies
+├── overlays/
+│   ├── dev/                   # Development overlay
+│   │   └── kustomization.yaml
+│   └── prod/                  # Production overlay
+│       ├── kustomization.yaml
+│       └── hpa.yaml           # HorizontalPodAutoscaler
+└── README.md
+```
+
+## Components
+
+### Server Deployment
+- REST API on port 8080
+- gRPC endpoint on port 9443
+- Prometheus metrics on port 9090
+- Runs as non-root user (65532)
+- ReadWriteOnce PVC for SQLite
+
+### Agent DaemonSet
+- Runs on every node (configurable via nodeSelector)
+- Collects logs from host directories
+- RBAC for pod/node metadata enrichment
+- Tolerates all taints by default
+
+### ClickHouse StatefulSet
+- Log storage for production
+- 100Gi PVC per replica
+- Native (9000) and HTTP (8123) ports
+- Optional: use external ClickHouse instead
+
+### Networking
+- **Ingress**: Nginx ingress for Web UI
+- **NetworkPolicy**: Restricts traffic between components
+- **Services**: ClusterIP for internal, LoadBalancer optional
+
+## Configuration
+
+### Secrets
+
+**Required secrets:**
+```bash
+kubectl create secret generic blazelog-secrets \
+  --namespace=blazelog \
+  --from-literal=master-key="$(openssl rand -base64 32)" \
+  --from-literal=jwt-secret="$(openssl rand -base64 32)" \
+  --from-literal=csrf-secret="$(openssl rand -base64 32)" \
+  --from-literal=clickhouse-password="$(openssl rand -base64 16)"
+```
+
+**TLS for mTLS (optional):**
+```bash
+kubectl create secret tls blazelog-tls \
+  --namespace=blazelog \
+  --cert=server.crt \
+  --key=server.key
+
+kubectl create secret generic blazelog-ca \
+  --namespace=blazelog \
+  --from-file=ca.crt
+```
+
+### ConfigMaps
+
+Server configuration in `server-configmap.yaml`. Key settings:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `clickhouse.enabled` | Enable ClickHouse storage | `false` |
+| `tls.enabled` | Enable mTLS for agents | `false` |
+| `auth.access_token_ttl` | JWT access token TTL | `15m` |
+| `auth.refresh_token_ttl` | JWT refresh token TTL | `168h` |
+
+### Ingress
+
+Update `ingress.yaml` with your domain:
+```yaml
+spec:
+  rules:
+    - host: your-domain.com
+```
+
+For TLS with cert-manager:
+```yaml
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+```
+
+## Deployment Options
+
+### Development (SQLite only)
+```bash
+kubectl apply -k deployments/kubernetes/overlays/dev
+```
+- Reduced resource limits
+- SQLite storage
+- Suitable for testing
+
+### Production (ClickHouse)
+```bash
+kubectl apply -k deployments/kubernetes/overlays/prod
+```
+- Full resource allocation
+- ClickHouse for log storage
+- HPA enabled
+- Network policies enforced
+
+### External ClickHouse
+
+To use external ClickHouse instead of StatefulSet:
+
+1. Remove ClickHouse from kustomization:
+```yaml
+resources:
+  # - clickhouse-statefulset.yaml
+  # - clickhouse-service.yaml
+```
+
+2. Update server ConfigMap:
+```yaml
+clickhouse:
+  enabled: true
+  addresses:
+    - "external-clickhouse.example.com:9000"
+```
+
+## Operations
+
+### Scaling
+
+**Note:** Server requires external database for horizontal scaling (SQLite is single-node).
+
+```bash
+# View current replicas
+kubectl get deploy -n blazelog
+
+# Scale (only with external DB)
+kubectl scale deploy blazelog-server -n blazelog --replicas=3
+```
+
+### Monitoring
+
+Prometheus metrics available at `:9090/metrics`:
+```bash
+kubectl port-forward -n blazelog svc/blazelog-server 9090:9090
+curl http://localhost:9090/metrics
+```
+
+### Logs
+
+```bash
+# Server logs
+kubectl logs -n blazelog -l app.kubernetes.io/component=server -f
+
+# Agent logs (all nodes)
+kubectl logs -n blazelog -l app.kubernetes.io/component=agent -f
+
+# ClickHouse logs
+kubectl logs -n blazelog -l app.kubernetes.io/component=clickhouse -f
+```
+
+### Health Checks
+
+```bash
+# Server health
+kubectl exec -n blazelog deploy/blazelog-server -- \
+  wget -qO- http://localhost:8080/health/ready
+
+# ClickHouse health
+kubectl exec -n blazelog sts/blazelog-clickhouse -- \
+  clickhouse-client --query "SELECT 1"
+```
+
+### Backup
+
+**SQLite (data PVC):**
+```bash
+kubectl exec -n blazelog deploy/blazelog-server -- \
+  sqlite3 /data/blazelog.db ".backup /tmp/backup.db"
+kubectl cp blazelog/$(kubectl get pod -n blazelog -l app.kubernetes.io/component=server -o jsonpath='{.items[0].metadata.name}'):/tmp/backup.db ./blazelog-backup.db
+```
+
+**ClickHouse:**
+```bash
+kubectl exec -n blazelog sts/blazelog-clickhouse-0 -- \
+  clickhouse-client --query "BACKUP DATABASE blazelog TO Disk('backups', 'blazelog')"
+```
+
+## Troubleshooting
+
+### Pod not starting
+
+```bash
+# Check events
+kubectl describe pod -n blazelog <pod-name>
+
+# Check logs
+kubectl logs -n blazelog <pod-name> --previous
+```
+
+### Network connectivity issues
+
+```bash
+# Test server→clickhouse
+kubectl exec -n blazelog deploy/blazelog-server -- \
+  nc -zv blazelog-clickhouse 9000
+
+# Test agent→server
+kubectl exec -n blazelog ds/blazelog-agent -- \
+  nc -zv blazelog-server 9443
+```
+
+### Storage issues
+
+```bash
+# Check PVC status
+kubectl get pvc -n blazelog
+
+# Check PV binding
+kubectl describe pvc -n blazelog blazelog-data
+```
+
+## Cleanup
+
+```bash
+# Delete all resources
+kubectl delete -k deployments/kubernetes/base
+
+# Delete namespace (removes everything)
+kubectl delete namespace blazelog
+
+# Delete PVCs separately (not deleted with namespace)
+kubectl delete pvc -n blazelog --all
+```
+
+## Requirements
+
+- Kubernetes 1.25+
+- kubectl configured
+- Ingress controller (nginx-ingress recommended)
+- CNI with NetworkPolicy support (Calico, Cilium)
+- Storage class for PVCs
+- Optional: cert-manager for TLS

--- a/deployments/kubernetes/base/agent-configmap.yaml
+++ b/deployments/kubernetes/base/agent-configmap.yaml
@@ -1,0 +1,83 @@
+# BlazeLog Agent ConfigMap
+#
+# Agent configuration for Kubernetes deployment
+# Collects logs from host directories mounted to the pod
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blazelog-agent-config
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: agent
+data:
+  agent.yaml: |
+    # BlazeLog Agent Configuration for Kubernetes
+    #
+    # Deployed as DaemonSet, collects logs from host volumes
+
+    # Server connection settings
+    server:
+      # BlazeLog server ClusterIP service
+      address: "blazelog-server:9443"
+
+      # TLS configuration for mTLS
+      # Enable for production with server authentication
+      tls:
+        enabled: false
+        # Uncomment when using TLS:
+        # cert_file: "/etc/blazelog/certs/tls.crt"
+        # key_file: "/etc/blazelog/certs/tls.key"
+        # ca_file: "/etc/blazelog/certs/ca.crt"
+
+    # Agent settings
+    agent:
+      # Name auto-set from NODE_NAME env var
+      name: ""
+      batch_size: 100
+      flush_interval: 1s
+
+    # Log sources from host volumes
+    # Paths are relative to volume mounts in DaemonSet
+    sources:
+      # System logs
+      - name: "syslog"
+        type: "auto"
+        path: "/var/log/syslog"
+        follow: true
+
+      - name: "messages"
+        type: "auto"
+        path: "/var/log/messages"
+        follow: true
+
+      # Container logs (Docker)
+      - name: "docker-containers"
+        type: "auto"
+        path: "/var/lib/docker/containers/*/*.log"
+        follow: true
+
+      # Container logs (containerd/CRI-O)
+      - name: "pod-logs"
+        type: "auto"
+        path: "/var/log/pods/*/*/*/*.log"
+        follow: true
+
+      # Kubernetes component logs
+      - name: "kubelet"
+        type: "auto"
+        path: "/var/log/kubelet.log"
+        follow: true
+
+      # Add application-specific sources as needed:
+      # - name: "nginx"
+      #   type: "nginx"
+      #   path: "/var/log/nginx/*.log"
+      #   follow: true
+
+    # Labels for categorization
+    # NODE_NAME injected via downward API
+    labels:
+      environment: "kubernetes"
+      collector: "daemonset"

--- a/deployments/kubernetes/base/agent-daemonset.yaml
+++ b/deployments/kubernetes/base/agent-daemonset.yaml
@@ -1,0 +1,161 @@
+# BlazeLog Agent DaemonSet
+#
+# Deploys BlazeLog agent on every node (or selected nodes) to collect logs.
+# Mounts host log directories read-only for collection.
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: blazelog-agent
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: agent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: blazelog
+      app.kubernetes.io/component: agent
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: blazelog
+        app.kubernetes.io/component: agent
+    spec:
+      serviceAccountName: blazelog-agent
+      # Tolerate all taints to run on all nodes
+      tolerations:
+        - operator: Exists
+      # Optional: Select specific nodes
+      # nodeSelector:
+      #   kubernetes.io/os: linux
+      #   blazelog/collect-logs: "true"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: agent
+          image: blazelog/agent:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-c"
+            - "/etc/blazelog/agent.yaml"
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: config
+              mountPath: /etc/blazelog
+              readOnly: true
+            - name: tls-certs
+              mountPath: /etc/blazelog/certs
+              readOnly: true
+            - name: agent-state
+              mountPath: /var/lib/blazelog
+            # Host log directories (read-only)
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            # For containerd runtime
+            - name: containerd-logs
+              mountPath: /var/log/pods
+              readOnly: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: blazelog-agent-config
+        - name: tls-certs
+          secret:
+            secretName: blazelog-tls
+            optional: true
+        - name: agent-state
+          emptyDir: {}
+        # Host paths for log collection
+        - name: varlog
+          hostPath:
+            path: /var/log
+            type: Directory
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+            type: DirectoryOrCreate
+        - name: containerd-logs
+          hostPath:
+            path: /var/log/pods
+            type: DirectoryOrCreate
+---
+# ServiceAccount for agent
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: blazelog-agent
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: agent
+---
+# ClusterRole for agent (read pods/nodes for metadata enrichment)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: blazelog-agent
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: agent
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+---
+# ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: blazelog-agent
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: blazelog-agent
+subjects:
+  - kind: ServiceAccount
+    name: blazelog-agent
+    namespace: blazelog

--- a/deployments/kubernetes/base/clickhouse-service.yaml
+++ b/deployments/kubernetes/base/clickhouse-service.yaml
@@ -1,0 +1,58 @@
+# BlazeLog ClickHouse Services
+#
+# Services for ClickHouse database access:
+# - Headless service for StatefulSet
+# - ClusterIP for internal access
+---
+# Headless Service for StatefulSet
+apiVersion: v1
+kind: Service
+metadata:
+  name: blazelog-clickhouse-headless
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: clickhouse
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: clickhouse
+  ports:
+    - name: native
+      port: 9000
+      targetPort: native
+      protocol: TCP
+    - name: http
+      port: 8123
+      targetPort: http
+      protocol: TCP
+    - name: interserver
+      port: 9009
+      targetPort: interserver
+      protocol: TCP
+---
+# ClusterIP Service for application access
+apiVersion: v1
+kind: Service
+metadata:
+  name: blazelog-clickhouse
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: clickhouse
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: clickhouse
+  ports:
+    - name: native
+      port: 9000
+      targetPort: native
+      protocol: TCP
+    - name: http
+      port: 8123
+      targetPort: http
+      protocol: TCP

--- a/deployments/kubernetes/base/clickhouse-statefulset.yaml
+++ b/deployments/kubernetes/base/clickhouse-statefulset.yaml
@@ -1,0 +1,145 @@
+# BlazeLog ClickHouse StatefulSet
+#
+# Deploys ClickHouse for log storage in production.
+# Uses StatefulSet for stable network identity and persistent storage.
+#
+# For external ClickHouse:
+# - Skip this manifest
+# - Update server ConfigMap with external ClickHouse address
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: blazelog-clickhouse
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: clickhouse
+spec:
+  serviceName: blazelog-clickhouse-headless
+  replicas: 1  # Single replica; use ClickHouse Operator for HA
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: blazelog
+      app.kubernetes.io/component: clickhouse
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: blazelog
+        app.kubernetes.io/component: clickhouse
+    spec:
+      securityContext:
+        fsGroup: 101  # clickhouse group
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:24.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: native
+              containerPort: 9000
+              protocol: TCP
+            - name: http
+              containerPort: 8123
+              protocol: TCP
+            - name: interserver
+              containerPort: 9009
+              protocol: TCP
+          env:
+            - name: CLICKHOUSE_DB
+              value: "blazelog"
+            - name: CLICKHOUSE_USER
+              value: "blazelog"
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: blazelog-secrets
+                  key: clickhouse-password
+            - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
+              value: "1"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/clickhouse
+            - name: logs
+              mountPath: /var/log/clickhouse-server
+            - name: config
+              mountPath: /etc/clickhouse-server/config.d
+              readOnly: true
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi
+            limits:
+              cpu: "4"
+              memory: 8Gi
+          livenessProbe:
+            exec:
+              command:
+                - clickhouse-client
+                - --query
+                - SELECT 1
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - clickhouse-client
+                - --query
+                - SELECT 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: config
+          configMap:
+            name: blazelog-clickhouse-config
+        - name: logs
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: blazelog
+          app.kubernetes.io/component: clickhouse
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Gi
+        # storageClassName: fast-ssd
+---
+# ConfigMap for ClickHouse custom settings
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blazelog-clickhouse-config
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: clickhouse
+data:
+  performance.xml: |
+    <?xml version="1.0"?>
+    <clickhouse>
+        <max_connections>100</max_connections>
+        <max_concurrent_queries>50</max_concurrent_queries>
+        <mark_cache_size>5368709120</mark_cache_size>
+        <max_server_memory_usage_to_ram_ratio>0.8</max_server_memory_usage_to_ram_ratio>
+    </clickhouse>
+
+  logging.xml: |
+    <?xml version="1.0"?>
+    <clickhouse>
+        <logger>
+            <level>information</level>
+            <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+            <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+            <size>100M</size>
+            <count>5</count>
+        </logger>
+    </clickhouse>

--- a/deployments/kubernetes/base/ingress.yaml
+++ b/deployments/kubernetes/base/ingress.yaml
@@ -1,0 +1,91 @@
+# BlazeLog Ingress
+#
+# Exposes BlazeLog Web UI and API via Ingress controller.
+# Supports nginx-ingress, traefik, and cloud ingress controllers.
+#
+# Prerequisites:
+# - Ingress controller installed (nginx-ingress, traefik, etc.)
+# - TLS certificate (via cert-manager or pre-created secret)
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: blazelog
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: ingress
+  annotations:
+    # nginx-ingress annotations
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    # Enable WebSocket for real-time log streaming
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
+
+    # Security headers
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header X-XSS-Protection "1; mode=block" always;
+      add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Rate limiting (optional)
+    # nginx.ingress.kubernetes.io/limit-rps: "100"
+    # nginx.ingress.kubernetes.io/limit-connections: "50"
+
+    # cert-manager for automatic TLS
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+
+    # Traefik annotations (uncomment if using Traefik)
+    # traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
+    # traefik.ingress.kubernetes.io/router.tls: "true"
+
+    # AWS ALB annotations (uncomment if using AWS ALB)
+    # kubernetes.io/ingress.class: alb
+    # alb.ingress.kubernetes.io/scheme: internet-facing
+    # alb.ingress.kubernetes.io/target-type: ip
+    # alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:...
+
+    # GCP annotations (uncomment if using GKE)
+    # kubernetes.io/ingress.class: gce
+spec:
+  ingressClassName: nginx  # Change to your ingress controller
+  tls:
+    - hosts:
+        - blazelog.example.com
+      secretName: blazelog-ingress-tls
+  rules:
+    - host: blazelog.example.com
+      http:
+        paths:
+          # Web UI and REST API
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: blazelog-server
+                port:
+                  name: http
+---
+# Example TLS Secret (for manual certificate)
+# Create with:
+#   kubectl create secret tls blazelog-ingress-tls \
+#     --namespace=blazelog \
+#     --cert=blazelog.crt \
+#     --key=blazelog.key
+#
+# Or use cert-manager for automatic provisioning
+apiVersion: v1
+kind: Secret
+metadata:
+  name: blazelog-ingress-tls
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: ingress
+type: kubernetes.io/tls
+data:
+  tls.crt: ""  # Base64-encoded certificate
+  tls.key: ""  # Base64-encoded private key

--- a/deployments/kubernetes/base/kustomization.yaml
+++ b/deployments/kubernetes/base/kustomization.yaml
@@ -1,0 +1,55 @@
+# BlazeLog Kubernetes Base Kustomization
+#
+# Base resources for all environments.
+# Use overlays for environment-specific customizations.
+#
+# Apply directly: kubectl apply -k deployments/kubernetes/base
+# Apply with overlay: kubectl apply -k deployments/kubernetes/overlays/prod
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: blazelog
+
+labels:
+  - pairs:
+      app.kubernetes.io/managed-by: kustomize
+      app.kubernetes.io/version: latest
+
+resources:
+  # Namespace (apply first)
+  - namespace.yaml
+
+  # Secrets (template - replace with actual secrets or sealed-secrets)
+  - secrets.yaml
+
+  # Storage
+  - pvc.yaml
+
+  # Server components
+  - server-configmap.yaml
+  - server-deployment.yaml
+  - server-service.yaml
+
+  # Agent components
+  - agent-configmap.yaml
+  - agent-daemonset.yaml
+
+  # ClickHouse (optional - comment out for SQLite-only)
+  - clickhouse-statefulset.yaml
+  - clickhouse-service.yaml
+
+  # Networking
+  - ingress.yaml
+  - networkpolicy.yaml
+
+# Common labels
+commonLabels:
+  app.kubernetes.io/part-of: blazelog
+
+# Images - override in overlays
+images:
+  - name: blazelog/server
+    newTag: latest
+  - name: blazelog/agent
+    newTag: latest

--- a/deployments/kubernetes/base/namespace.yaml
+++ b/deployments/kubernetes/base/namespace.yaml
@@ -1,0 +1,11 @@
+# BlazeLog Kubernetes Namespace
+#
+# Creates isolated namespace for all BlazeLog resources
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/part-of: blazelog

--- a/deployments/kubernetes/base/networkpolicy.yaml
+++ b/deployments/kubernetes/base/networkpolicy.yaml
@@ -1,0 +1,189 @@
+# BlazeLog NetworkPolicies
+#
+# Security policies to restrict network traffic between components.
+# Requires CNI that supports NetworkPolicy (Calico, Cilium, etc.)
+---
+# Default deny all ingress/egress in namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: network-security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+# Allow DNS resolution for all pods
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: network-security
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+# Server NetworkPolicy
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: blazelog-server
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: network-security
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: blazelog
+      app.kubernetes.io/component: server
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # HTTP from Ingress controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              # Adjust to match your ingress namespace
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 8080
+    # gRPC from agents
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: blazelog
+              app.kubernetes.io/component: agent
+      ports:
+        - protocol: TCP
+          port: 9443
+    # Metrics from Prometheus
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 9090
+  egress:
+    # ClickHouse
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: blazelog
+              app.kubernetes.io/component: clickhouse
+      ports:
+        - protocol: TCP
+          port: 9000
+    # External SMTP (email notifications)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 587
+        - protocol: TCP
+          port: 465
+    # External HTTPS (Slack/Teams webhooks)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+---
+# Agent NetworkPolicy
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: blazelog-agent
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: network-security
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: blazelog
+      app.kubernetes.io/component: agent
+  policyTypes:
+    - Egress
+  egress:
+    # Connect to BlazeLog server only
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: blazelog
+              app.kubernetes.io/component: server
+      ports:
+        - protocol: TCP
+          port: 9443
+---
+# ClickHouse NetworkPolicy
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: blazelog-clickhouse
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: network-security
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: blazelog
+      app.kubernetes.io/component: clickhouse
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Accept from server only
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: blazelog
+              app.kubernetes.io/component: server
+      ports:
+        - protocol: TCP
+          port: 9000
+        - protocol: TCP
+          port: 8123
+  egress:
+    # Inter-server communication (for future HA setup)
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: blazelog
+              app.kubernetes.io/component: clickhouse
+      ports:
+        - protocol: TCP
+          port: 9009

--- a/deployments/kubernetes/base/pvc.yaml
+++ b/deployments/kubernetes/base/pvc.yaml
@@ -1,0 +1,43 @@
+# BlazeLog PersistentVolumeClaims
+#
+# Storage for BlazeLog data:
+# - blazelog-data: SQLite database, SSH audit logs
+# - blazelog-certs: mTLS certificates (optional)
+---
+# Main data volume for SQLite and logs
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: blazelog-data
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  # Uncomment to use specific storage class:
+  # storageClassName: standard
+  # For SSD storage:
+  # storageClassName: fast-ssd
+---
+# Certificate volume for mTLS (optional)
+# Use if not using Kubernetes Secrets for TLS
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: blazelog-certs
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: storage
+spec:
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 1Gi
+  # storageClassName: standard

--- a/deployments/kubernetes/base/secrets.yaml
+++ b/deployments/kubernetes/base/secrets.yaml
@@ -1,0 +1,73 @@
+# BlazeLog Secrets Template
+#
+# IMPORTANT: This is a template! Do not commit actual secrets.
+# Create secrets using kubectl or sealed-secrets in production.
+#
+# Generate secrets:
+#   MASTER_KEY=$(openssl rand -base64 32)
+#   JWT_SECRET=$(openssl rand -base64 32)
+#   CSRF_SECRET=$(openssl rand -base64 32)
+#   CLICKHOUSE_PASSWORD=$(openssl rand -base64 16)
+#
+# Create secret:
+#   kubectl create secret generic blazelog-secrets \
+#     --namespace=blazelog \
+#     --from-literal=master-key="$MASTER_KEY" \
+#     --from-literal=jwt-secret="$JWT_SECRET" \
+#     --from-literal=csrf-secret="$CSRF_SECRET" \
+#     --from-literal=clickhouse-password="$CLICKHOUSE_PASSWORD"
+#
+# Or use this template with base64-encoded values:
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: blazelog-secrets
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: secrets
+type: Opaque
+data:
+  # Base64-encoded values (replace with actual secrets)
+  # echo -n "your-secret" | base64
+  master-key: ""      # BLAZELOG_MASTER_KEY - encryption key for sensitive data
+  jwt-secret: ""      # BLAZELOG_JWT_SECRET - JWT signing key
+  csrf-secret: ""     # BLAZELOG_CSRF_SECRET - CSRF protection (optional)
+  clickhouse-password: ""  # ClickHouse password (required for prod)
+---
+# TLS Secret for mTLS (optional)
+# Create with:
+#   kubectl create secret tls blazelog-tls \
+#     --namespace=blazelog \
+#     --cert=server.crt \
+#     --key=server.key
+#
+# Or create generic secret for CA:
+#   kubectl create secret generic blazelog-ca \
+#     --namespace=blazelog \
+#     --from-file=ca.crt
+apiVersion: v1
+kind: Secret
+metadata:
+  name: blazelog-tls
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: tls
+type: kubernetes.io/tls
+data:
+  tls.crt: ""  # Server certificate (base64)
+  tls.key: ""  # Server private key (base64)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: blazelog-ca
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: tls
+type: Opaque
+data:
+  ca.crt: ""  # CA certificate for client verification (base64)

--- a/deployments/kubernetes/base/server-configmap.yaml
+++ b/deployments/kubernetes/base/server-configmap.yaml
@@ -1,0 +1,83 @@
+# BlazeLog Server ConfigMap
+#
+# Server configuration for Kubernetes deployment
+# Secrets are injected via environment variables from Secrets
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blazelog-server-config
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: server
+data:
+  server.yaml: |
+    # BlazeLog Server Configuration for Kubernetes
+    #
+    # Secrets loaded from environment variables (Kubernetes Secrets)
+
+    server:
+      # gRPC listen address for agent connections
+      grpc_address: ":9443"
+
+      # HTTP listen address for REST API and Web UI
+      http_address: ":8080"
+
+      # TLS configuration for mTLS (mutual TLS)
+      # Enable for production with agent authentication
+      tls:
+        enabled: false
+        # Uncomment when using TLS secrets:
+        # cert_file: "/etc/blazelog/certs/tls.crt"
+        # key_file: "/etc/blazelog/certs/tls.key"
+        # client_ca_file: "/etc/blazelog/certs/ca.crt"
+
+    # Database configuration
+    # SQLite stored in PersistentVolume
+    database:
+      path: "/data/blazelog.db"
+
+    # Authentication configuration
+    # Secrets loaded from BLAZELOG_* environment variables
+    auth:
+      jwt_secret_env: "BLAZELOG_JWT_SECRET"
+      csrf_secret_env: "BLAZELOG_CSRF_SECRET"
+      access_token_ttl: "15m"
+      refresh_token_ttl: "168h"  # 7 days
+      rate_limit_per_ip: 100
+      rate_limit_per_user: 1000
+      lockout_threshold: 5
+      lockout_duration: "15m"
+
+    # SSH security settings (for agentless log collection)
+    ssh:
+      host_key_file: "/etc/blazelog/known_hosts"
+      host_key_policy: "strict"
+      audit_log: "/data/ssh-audit.log"
+      pool:
+        max_per_host: 5
+        idle_timeout: 5m
+
+    # Metrics configuration
+    metrics:
+      enabled: true
+      address: ":9090"
+
+    # ClickHouse configuration
+    # Enable for production with ClickHouse StatefulSet
+    clickhouse:
+      enabled: false
+      addresses:
+        - "blazelog-clickhouse:9000"
+      database: "blazelog"
+      username: "blazelog"
+      password_env: "CLICKHOUSE_PASSWORD"
+      batch_size: 10000
+      flush_interval: "5s"
+      max_buffer_size: 100000
+      max_open_conns: 10
+      retention_days: 90
+
+  # SSH known_hosts (empty by default)
+  known_hosts: ""

--- a/deployments/kubernetes/base/server-deployment.yaml
+++ b/deployments/kubernetes/base/server-deployment.yaml
@@ -1,0 +1,148 @@
+# BlazeLog Server Deployment
+#
+# Deploys the central BlazeLog server with:
+# - REST API for Web UI and management
+# - gRPC endpoint for agent connections
+# - Prometheus metrics endpoint
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blazelog-server
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: server
+spec:
+  replicas: 1  # Single replica for SQLite; scale horizontally only with external DB
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: blazelog
+      app.kubernetes.io/component: server
+  strategy:
+    type: Recreate  # Required for PVC with ReadWriteOnce
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: blazelog
+        app.kubernetes.io/component: server
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: blazelog-server
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+      containers:
+        - name: server
+          image: blazelog/server:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-c"
+            - "/etc/blazelog/server.yaml"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9443
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          env:
+            - name: BLAZELOG_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: blazelog-secrets
+                  key: master-key
+            - name: BLAZELOG_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: blazelog-secrets
+                  key: jwt-secret
+            - name: BLAZELOG_CSRF_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: blazelog-secrets
+                  key: csrf-secret
+                  optional: true
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: blazelog-secrets
+                  key: clickhouse-password
+                  optional: true
+          volumeMounts:
+            - name: config
+              mountPath: /etc/blazelog
+              readOnly: true
+            - name: data
+              mountPath: /data
+            - name: tls-certs
+              mountPath: /etc/blazelog/certs
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: config
+          configMap:
+            name: blazelog-server-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: blazelog-data
+        - name: tls-certs
+          secret:
+            secretName: blazelog-tls
+            optional: true
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: blazelog
+                    app.kubernetes.io/component: server
+                topologyKey: kubernetes.io/hostname
+---
+# ServiceAccount for server
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: blazelog-server
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: server

--- a/deployments/kubernetes/base/server-service.yaml
+++ b/deployments/kubernetes/base/server-service.yaml
@@ -1,0 +1,91 @@
+# BlazeLog Server Services
+#
+# Exposes server endpoints:
+# - ClusterIP for internal access (default)
+# - LoadBalancer for external access (optional)
+---
+# ClusterIP Service - Internal access
+apiVersion: v1
+kind: Service
+metadata:
+  name: blazelog-server
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: server
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: server
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9443
+      targetPort: grpc
+      protocol: TCP
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP
+---
+# Headless Service - For direct pod addressing (optional)
+apiVersion: v1
+kind: Service
+metadata:
+  name: blazelog-server-headless
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: server
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: server
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9443
+      targetPort: grpc
+      protocol: TCP
+---
+# LoadBalancer Service - External access (use sparingly)
+# Uncomment to expose server directly via cloud LoadBalancer
+# Prefer Ingress for HTTP traffic
+#
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: blazelog-server-lb
+#   namespace: blazelog
+#   labels:
+#     app.kubernetes.io/name: blazelog
+#     app.kubernetes.io/component: server
+#   annotations:
+#     # AWS annotations (uncomment for AWS)
+#     # service.beta.kubernetes.io/aws-load-balancer-type: nlb
+#     # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+#     # GCP annotations (uncomment for GCP)
+#     # cloud.google.com/load-balancer-type: Internal
+# spec:
+#   type: LoadBalancer
+#   selector:
+#     app.kubernetes.io/name: blazelog
+#     app.kubernetes.io/component: server
+#   ports:
+#     - name: http
+#       port: 80
+#       targetPort: http
+#       protocol: TCP
+#     - name: grpc
+#       port: 9443
+#       targetPort: grpc
+#       protocol: TCP

--- a/deployments/kubernetes/overlays/dev/kustomization.yaml
+++ b/deployments/kubernetes/overlays/dev/kustomization.yaml
@@ -1,0 +1,84 @@
+# BlazeLog Kubernetes Development Overlay
+#
+# Development environment with:
+# - SQLite only (no ClickHouse)
+# - Reduced resource requests
+# - NodePort for local access
+#
+# Apply: kubectl apply -k deployments/kubernetes/overlays/dev
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: blazelog
+
+resources:
+  - ../../base
+
+# Override images to dev tag
+images:
+  - name: blazelog/server
+    newTag: dev
+  - name: blazelog/agent
+    newTag: dev
+
+# Patches for development
+patches:
+  # Reduce server resources
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: blazelog-server
+      spec:
+        template:
+          spec:
+            containers:
+              - name: server
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 128Mi
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+
+  # Reduce agent resources
+  - patch: |-
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: blazelog-agent
+      spec:
+        template:
+          spec:
+            containers:
+              - name: agent
+                resources:
+                  requests:
+                    cpu: 10m
+                    memory: 32Mi
+                  limits:
+                    cpu: 100m
+                    memory: 128Mi
+
+  # Smaller PVC for dev
+  - patch: |-
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: blazelog-data
+      spec:
+        resources:
+          requests:
+            storage: 1Gi
+
+# Remove ClickHouse for dev (SQLite-only)
+# Uncomment to disable ClickHouse in dev
+# patchesStrategicMerge:
+#   - |-
+#     $patch: delete
+#     apiVersion: apps/v1
+#     kind: StatefulSet
+#     metadata:
+#       name: blazelog-clickhouse

--- a/deployments/kubernetes/overlays/prod/hpa.yaml
+++ b/deployments/kubernetes/overlays/prod/hpa.yaml
@@ -1,0 +1,52 @@
+# BlazeLog HorizontalPodAutoscaler
+#
+# Auto-scales server based on CPU/memory usage.
+# Note: Requires external database for horizontal scaling.
+#
+# For SQLite deployments, keep maxReplicas: 1
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: blazelog-server
+  namespace: blazelog
+  labels:
+    app.kubernetes.io/name: blazelog
+    app.kubernetes.io/component: server
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: blazelog-server
+  minReplicas: 1
+  maxReplicas: 1  # Keep at 1 for SQLite; increase only with external DB
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 15
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+      selectPolicy: Max

--- a/deployments/kubernetes/overlays/prod/kustomization.yaml
+++ b/deployments/kubernetes/overlays/prod/kustomization.yaml
@@ -1,0 +1,98 @@
+# BlazeLog Kubernetes Production Overlay
+#
+# Production environment with:
+# - ClickHouse for log storage
+# - Production resource limits
+# - Network policies enabled
+# - HPA for auto-scaling
+#
+# Apply: kubectl apply -k deployments/kubernetes/overlays/prod
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: blazelog
+
+resources:
+  - ../../base
+  - hpa.yaml
+
+# Override images to specific version
+images:
+  - name: blazelog/server
+    newTag: "1.0.0"  # Pin to specific version
+  - name: blazelog/agent
+    newTag: "1.0.0"
+
+# Production ConfigMap patch to enable ClickHouse
+configMapGenerator:
+  - name: blazelog-server-config
+    behavior: merge
+    literals:
+      - clickhouse_enabled=true
+
+patches:
+  # Production server resources
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: blazelog-server
+      spec:
+        template:
+          spec:
+            containers:
+              - name: server
+                resources:
+                  requests:
+                    cpu: 500m
+                    memory: 1Gi
+                  limits:
+                    cpu: "4"
+                    memory: 4Gi
+
+  # Production ClickHouse resources
+  - patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: blazelog-clickhouse
+      spec:
+        template:
+          spec:
+            containers:
+              - name: clickhouse
+                resources:
+                  requests:
+                    cpu: "1"
+                    memory: 4Gi
+                  limits:
+                    cpu: "8"
+                    memory: 16Gi
+
+  # Production storage size
+  - patch: |-
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: blazelog-data
+      spec:
+        resources:
+          requests:
+            storage: 50Gi
+
+  # Update Ingress host
+  - patch: |-
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: blazelog
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-prod
+      spec:
+        tls:
+          - hosts:
+              - logs.example.com
+            secretName: blazelog-prod-tls
+        rules:
+          - host: logs.example.com


### PR DESCRIPTION
## Summary

- Add complete Kubernetes deployment manifests for BlazeLog stack
- Server Deployment with ConfigMap, PVC, and Services (ClusterIP + Headless)
- Agent DaemonSet with RBAC for node-level log collection
- ClickHouse StatefulSet for production log storage
- Ingress with nginx annotations and TLS support
- NetworkPolicies (default-deny + per-component rules)
- Secrets templates for master-key, JWT, TLS certificates
- Kustomize overlays for dev (SQLite) and prod (ClickHouse) environments
- HorizontalPodAutoscaler for production scaling
- Comprehensive deployment documentation with architecture diagram

## Test plan

- [ ] Verify manifests pass `kubectl apply --dry-run=client`
- [ ] Test dev overlay deployment on local cluster (minikube/kind)
- [ ] Test prod overlay with ClickHouse StatefulSet
- [ ] Verify NetworkPolicies allow expected traffic patterns
- [ ] Test Ingress routing to Web UI

Closes #53